### PR TITLE
Updating readme to use explicit long plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ require("babel").transform("code", { plugins: ["rewire"] });
 with `webpack` use the following loader:
 
 ```javascript
-{test: /src\/js\/.+\.js$/, loader: 'babel-loader?plugins=rewire' }
+{test: /src\/js\/.+\.js$/, loader: 'babel-loader?plugins=babel-plugin-rewire' }
 ```
 
 ## Release History


### PR DESCRIPTION
To avoid conflicts with npm `require` module

Inspired by https://github.com/speedskater/babel-plugin-rewire/issues/5