### PR TITLE
add top-level var rewire support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ For compatibility reasons with rewire.js, the methods `__get__` and `__set__` ar
 These methods allow you to rewire the module under test.
 Furthermore in case of a default export these methods are assigned to the existing default export.
 
-##Example
-###React Component
+##ES6 Imports and React
+
+Dependencies from import statements can be rewired
+
+###Example
 
 ```javascript
 import ChildComponent from 'child-component-module';
@@ -42,14 +45,16 @@ ComponentToTest.__Rewire__('ChildComponent', React.createClass({
 ComponentToTest.__ResetDependency__('ChildComponent');
 ```
 
-##Node/browserify require() support
+##Node/browserify require() and top-level var support
 
-Dependencies declared using `require` are also supported.
+Variables declared and initialised at the top level, such as those from require() calls, can be rewired
 
 ###Example
 
 ```javascript
 var Path = require('path');
+
+var env = 'production';
 
 module.exports = function(name) {
 	return Path.normalise(name);
@@ -59,12 +64,13 @@ module.exports = function(name) {
 ### Test Code
 
 ```javascript
-
 var Normaliser = require('Normaliser');
 
 Normaliser.__Rewire__('Path', {
   normalise: (name) => name;
 });
+
+Normaliser.__Rewire__('env', 'testing');
 ....
 
 Normaliser.__ResetDependency__('Path');
@@ -133,11 +139,11 @@ var appBundler = browserify({
 * 0.1.3 Added handling for the export of named declarations like classes or functions
 * 0.1.4 Fixed variable handling and used renaming of scope variables. Further removed global identifiers to prevent memory leaks.
 * 0.1.5 Fixed regression
-* 0.1.6 Added require() support
+* 0.1.6 Support for rewiring top level variables. Added module.exports for non-es6 modules.
 
 ## Contributors
 
-[Peet](https://github.com/peet) - require() support
+[Peet](https://github.com/peet) - module.exports and top-level var support
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ It is inspired by [rewire.js](https://github.com/jhnns/rewire) and transfers its
 
 It is useful for writing tests, specifically to mock the dependencies of the module under test.
 
-Therefore for each module it adds and exports the methods \_\_GetDependency\_\_, \_\_Rewire\_\_, and \_\_ResetDependency\_\_.
-These methods allow to rewire the module under test.
-Furthermore in case of a default export these methods are assigned to the existing default export. For compatibility reasons with rewire.js, the methods \_\_get\_\_ and \_\_set\_\_ are assigned to the default export as well.
+Therefore for each module it adds and exports the methods `__GetDependency__`, `__Rewire__`, and `__ResetDependency__`.
+For compatibility reasons with rewire.js, the methods `__get__` and `__set__` are exported as well.
+These methods allow you to rewire the module under test.
+Furthermore in case of a default export these methods are assigned to the existing default export.
 
 ##Example
 ###React Component
@@ -39,6 +40,34 @@ ComponentToTest.__Rewire__('ChildComponent', React.createClass({
 ....
 
 ComponentToTest.__ResetDependency__('ChildComponent');
+```
+
+##Node/browserify require() support
+
+Dependencies declared using `require` are also supported.
+
+###Example
+
+```javascript
+var Path = require('path');
+
+module.exports = function(name) {
+	return Path.normalise(name);
+}
+```
+
+### Test Code
+
+```javascript
+
+var Normaliser = require('Normaliser');
+
+Normaliser.__Rewire__('Path', {
+  normalise: (name) => name;
+});
+....
+
+Normaliser.__ResetDependency__('Path');
 ```
 
 ## Installation
@@ -83,6 +112,19 @@ full plugin name:
 {test: /src\/js\/.+\.js$/, loader: 'babel-loader?plugins=babel-plugin-rewire' }
 ```
 
+### Browserify/Babelify
+
+full plugin name:
+```javascript
+var appBundler = browserify({
+    entries: [test.src], // Only need initial file, browserify finds the rest
+}).transform(
+    babelify.configure({
+        plugins: [require('babel-plugin-rewire')]
+    })
+);
+```
+
 ## Release History
 
 * 0.1.0 Initial release
@@ -91,6 +133,11 @@ full plugin name:
 * 0.1.3 Added handling for the export of named declarations like classes or functions
 * 0.1.4 Fixed variable handling and used renaming of scope variables. Further removed global identifiers to prevent memory leaks.
 * 0.1.5 Fixed regression
+* 0.1.6 Added require() support
+
+## Contributors
+
+[Peet](https://github.com/peet) - require() support
 
 ## License
 

--- a/fixtures/babelissue1315/expected.js
+++ b/fixtures/babelissue1315/expected.js
@@ -1,8 +1,5 @@
 'use strict';
 
-export { __GetDependency__ };
-export { __Rewire__ };
-export { __ResetDependency__ };
 import 'babel/polyfill';
 
 import 'underscore-wrapper';
@@ -27,9 +24,9 @@ import _$Temp from 'jquery';
 import _ie8IconsTemp from 'utils/ie8-icons';
 import _UserModelTemp from 'models/user';
 
-var __$Getters__ = [];
-var __$Setters__ = [];
-var __$Resetters__ = [];
+let __$Getters__ = [];
+let __$Setters__ = [];
+let __$Resetters__ = [];
 
 function __GetDependency__(name) {
 	return __$Getters__[name]();
@@ -43,61 +40,52 @@ function __ResetDependency__(name) {
 	__$Resetters__[name]();
 }
 
-var $ = _$Temp;
+let $ = _$Temp;
 
-function __set$__(value) {
-	$ = value;
-}
-
-function __get$__() {
+__$Getters__['$'] = function () {
 	return $;
-}
+};
 
-function __reset$__() {
+__$Setters__['$'] = function (value) {
+	$ = value;
+};
+
+__$Resetters__['$'] = function () {
 	$ = _$Temp;
-}
+};
 
-__$Getters__['$'] = __get$__;
-__$Setters__['$'] = __set$__;
-__$Resetters__['$'] = __reset$__;
-var ie8Icons = _ie8IconsTemp;
+let ie8Icons = _ie8IconsTemp;
 
-function __setie8Icons__(value) {
-	ie8Icons = value;
-}
-
-function __getie8Icons__() {
+__$Getters__['ie8Icons'] = function () {
 	return ie8Icons;
-}
+};
 
-function __resetie8Icons__() {
+__$Setters__['ie8Icons'] = function (value) {
+	ie8Icons = value;
+};
+
+__$Resetters__['ie8Icons'] = function () {
 	ie8Icons = _ie8IconsTemp;
-}
+};
 
-__$Getters__['ie8Icons'] = __getie8Icons__;
-__$Setters__['ie8Icons'] = __setie8Icons__;
-__$Resetters__['ie8Icons'] = __resetie8Icons__;
-var UserModel = _UserModelTemp;
+let UserModel = _UserModelTemp;
 
-function __setUserModel__(value) {
-	UserModel = value;
-}
-
-function __getUserModel__() {
+__$Getters__['UserModel'] = function () {
 	return UserModel;
-}
+};
 
-function __resetUserModel__() {
+__$Setters__['UserModel'] = function (value) {
+	UserModel = value;
+};
+
+__$Resetters__['UserModel'] = function () {
 	UserModel = _UserModelTemp;
-}
+};
 
-__$Getters__['UserModel'] = __getUserModel__;
-__$Setters__['UserModel'] = __setUserModel__;
-__$Resetters__['UserModel'] = __resetUserModel__;
-var a = 'b';
+let a = 'b';
 
-var user = UserModel.getCurrent();
-var moduleName = user && user.inState('activated') ? 'inside' : 'outside';
+const user = UserModel.getCurrent();
+const moduleName = user && user.inState('activated') ? 'inside' : 'outside';
 
 // Main app entryPoint
 if (moduleName === 'inside') {
@@ -113,6 +101,9 @@ else if (moduleName === 'outside') {
 	});
 }
 
-$(function () {
-	return ie8Icons.fix();
-});
+$(() => ie8Icons.fix());
+export { __GetDependency__ };
+export { __GetDependency__ as __get__ };
+export { __Rewire__ };
+export { __Rewire__ as __set__ };
+export { __ResetDependency__ };

--- a/fixtures/babelissue1315/expected.js
+++ b/fixtures/babelissue1315/expected.js
@@ -84,8 +84,50 @@ __$Resetters__['UserModel'] = function () {
 
 let a = 'b';
 
-const user = UserModel.getCurrent();
-const moduleName = user && user.inState('activated') ? 'inside' : 'outside';
+let _a = a;
+
+__$Getters__['a'] = function () {
+	return a;
+};
+
+__$Setters__['a'] = function (value) {
+	a = value;
+};
+
+__$Resetters__['a'] = function () {
+	a = _a;
+};
+
+let user = UserModel.getCurrent();
+let _user = user;
+
+__$Getters__['user'] = function () {
+	return user;
+};
+
+__$Setters__['user'] = function (value) {
+	user = value;
+};
+
+__$Resetters__['user'] = function () {
+	user = _user;
+};
+
+let moduleName = user && user.inState('activated') ? 'inside' : 'outside';
+
+let _moduleName = moduleName;
+
+__$Getters__['moduleName'] = function () {
+	return moduleName;
+};
+
+__$Setters__['moduleName'] = function (value) {
+	moduleName = value;
+};
+
+__$Resetters__['moduleName'] = function () {
+	moduleName = _moduleName;
+};
 
 // Main app entryPoint
 if (moduleName === 'inside') {

--- a/fixtures/defaultExport/expected.js
+++ b/fixtures/defaultExport/expected.js
@@ -1,13 +1,10 @@
 "use strict";
 
-export { __GetDependency__ };
-export { __Rewire__ };
-export { __ResetDependency__ };
 import _MyModuleTemp from "path/to/MyModule.js";
 
-var __$Getters__ = [];
-var __$Setters__ = [];
-var __$Resetters__ = [];
+let __$Getters__ = [];
+let __$Setters__ = [];
+let __$Resetters__ = [];
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
@@ -21,23 +18,20 @@ function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
-var MyModule = _MyModuleTemp;
+let MyModule = _MyModuleTemp;
 
-function __setMyModule__(value) {
-  MyModule = value;
-}
-
-function __getMyModule__() {
+__$Getters__["MyModule"] = function () {
   return MyModule;
-}
+};
 
-function __resetMyModule__() {
+__$Setters__["MyModule"] = function (value) {
+  MyModule = value;
+};
+
+__$Resetters__["MyModule"] = function () {
   MyModule = _MyModuleTemp;
-}
+};
 
-__$Getters__["MyModule"] = __getMyModule__;
-__$Setters__["MyModule"] = __setMyModule__;
-__$Resetters__["MyModule"] = __resetMyModule__;
 export default Object.assign("", {
   "__Rewire__": __Rewire__,
   "__set__": __Rewire__,
@@ -45,3 +39,8 @@ export default Object.assign("", {
   "__GetDependency__": __GetDependency__,
   "__get__": __GetDependency__
 });
+export { __GetDependency__ };
+export { __GetDependency__ as __get__ };
+export { __Rewire__ };
+export { __Rewire__ as __set__ };
+export { __ResetDependency__ };

--- a/fixtures/defaultExportWithClass/expected.js
+++ b/fixtures/defaultExportWithClass/expected.js
@@ -1,16 +1,10 @@
 'use strict';
 
-export { __GetDependency__ };
-export { __Rewire__ };
-export { __ResetDependency__ };
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
-
 import _fetchTemp from 'isomorphic-fetch';
 
-var __$Getters__ = [];
-var __$Setters__ = [];
-var __$Resetters__ = [];
+let __$Getters__ = [];
+let __$Setters__ = [];
+let __$Resetters__ = [];
 
 function __GetDependency__(name) {
     return __$Getters__[name]();
@@ -24,34 +18,30 @@ function __ResetDependency__(name) {
     __$Resetters__[name]();
 }
 
-var fetch = _fetchTemp;
+let fetch = _fetchTemp;
 
-function __setfetch__(value) {
-    fetch = value;
-}
-
-function __getfetch__() {
+__$Getters__['fetch'] = function () {
     return fetch;
-}
-
-function __resetfetch__() {
-    fetch = _fetchTemp;
-}
-
-__$Getters__['fetch'] = __getfetch__;
-__$Setters__['fetch'] = __setfetch__;
-__$Resetters__['fetch'] = __resetfetch__;
-
-var EclipseClient = function EclipseClient() {
-    _classCallCheck(this, EclipseClient);
-
-    if (process.env.NODE_ENV !== 'production') {
-        this.apiUrl = 'http:///';
-    } else {
-        this.apiUrl = 'http:///';
-    }
 };
 
+__$Setters__['fetch'] = function (value) {
+    fetch = value;
+};
+
+__$Resetters__['fetch'] = function () {
+    fetch = _fetchTemp;
+};
+
+class EclipseClient {
+    constructor() {
+        if (process.env.NODE_ENV !== 'production') {
+            this.apiUrl = 'http:///';
+        } else {
+            this.apiUrl = 'http:///';
+        }
+    }
+
+}
 export default Object.assign(EclipseClient, {
     '__Rewire__': __Rewire__,
     '__set__': __Rewire__,
@@ -59,3 +49,8 @@ export default Object.assign(EclipseClient, {
     '__GetDependency__': __GetDependency__,
     '__get__': __GetDependency__
 });
+export { __GetDependency__ };
+export { __GetDependency__ as __get__ };
+export { __Rewire__ };
+export { __Rewire__ as __set__ };
+export { __ResetDependency__ };

--- a/fixtures/defaultExportWithNamedFunction/expected.js
+++ b/fixtures/defaultExportWithNamedFunction/expected.js
@@ -1,13 +1,10 @@
 "use strict";
 
-export { __GetDependency__ };
-export { __Rewire__ };
-export { __ResetDependency__ };
 import _myDependencyTemp from "dependency";
 
-var __$Getters__ = [];
-var __$Setters__ = [];
-var __$Resetters__ = [];
+let __$Getters__ = [];
+let __$Setters__ = [];
+let __$Resetters__ = [];
 
 function __GetDependency__(name) {
 	return __$Getters__[name]();
@@ -21,23 +18,20 @@ function __ResetDependency__(name) {
 	__$Resetters__[name]();
 }
 
-var myDependency = _myDependencyTemp;
+let myDependency = _myDependencyTemp;
 
-function __setmyDependency__(value) {
-	myDependency = value;
-}
-
-function __getmyDependency__() {
+__$Getters__["myDependency"] = function () {
 	return myDependency;
-}
+};
 
-function __resetmyDependency__() {
+__$Setters__["myDependency"] = function (value) {
+	myDependency = value;
+};
+
+__$Resetters__["myDependency"] = function () {
 	myDependency = _myDependencyTemp;
-}
+};
 
-__$Getters__["myDependency"] = __getmyDependency__;
-__$Setters__["myDependency"] = __setmyDependency__;
-__$Resetters__["myDependency"] = __resetmyDependency__;
 function helloWorld() {
 	console.log("Hello World!");
 }
@@ -48,3 +42,8 @@ export default Object.assign(helloWorld, {
 	"__GetDependency__": __GetDependency__,
 	"__get__": __GetDependency__
 });
+export { __GetDependency__ };
+export { __GetDependency__ as __get__ };
+export { __Rewire__ };
+export { __Rewire__ as __set__ };
+export { __ResetDependency__ };

--- a/fixtures/multipleImports/expected.js
+++ b/fixtures/multipleImports/expected.js
@@ -1,12 +1,9 @@
 'use strict';
 
-export { __GetDependency__ };
-export { __Rewire__ };
-export { __ResetDependency__ };
 import { first as _firstTemp, second as _secondTemp } from 'path/to/another/LargeModules.js';
-var __$Getters__ = [];
-var __$Setters__ = [];
-var __$Resetters__ = [];
+let __$Getters__ = [];
+let __$Setters__ = [];
+let __$Resetters__ = [];
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
@@ -20,36 +17,35 @@ function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
-var first = _firstTemp;
-var second = _secondTemp;
+let first = _firstTemp;
+let second = _secondTemp;
 
-function __setfirst__(value) {
-  first = value;
-}
-
-function __setsecond__(value) {
-  second = value;
-}
-
-function __getfirst__() {
+__$Getters__['first'] = function () {
   return first;
-}
+};
 
-function __getsecond__() {
-  return second;
-}
+__$Setters__['first'] = function (value) {
+  first = value;
+};
 
-function __resetfirst__() {
+__$Resetters__['first'] = function () {
   first = _firstTemp;
-}
+};
 
-function __resetsecond__() {
+__$Getters__['second'] = function () {
+  return second;
+};
+
+__$Setters__['second'] = function (value) {
+  second = value;
+};
+
+__$Resetters__['second'] = function () {
   second = _secondTemp;
-}
+};
 
-__$Getters__['first'] = __getfirst__;
-__$Setters__['first'] = __setfirst__;
-__$Resetters__['first'] = __resetfirst__;
-__$Getters__['second'] = __getsecond__;
-__$Setters__['second'] = __setsecond__;
-__$Resetters__['second'] = __resetsecond__;
+export { __GetDependency__ };
+export { __GetDependency__ as __get__ };
+export { __Rewire__ };
+export { __Rewire__ as __set__ };
+export { __ResetDependency__ };

--- a/fixtures/multipleImportsWithAliases/expected.js
+++ b/fixtures/multipleImportsWithAliases/expected.js
@@ -1,12 +1,9 @@
 'use strict';
 
-export { __GetDependency__ };
-export { __Rewire__ };
-export { __ResetDependency__ };
 import { first as _unoTemp, second as _dueTemp } from 'path/to/another/LargeModules.js';
-var __$Getters__ = [];
-var __$Setters__ = [];
-var __$Resetters__ = [];
+let __$Getters__ = [];
+let __$Setters__ = [];
+let __$Resetters__ = [];
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
@@ -20,36 +17,35 @@ function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
-var uno = _unoTemp;
-var due = _dueTemp;
+let uno = _unoTemp;
+let due = _dueTemp;
 
-function __setuno__(value) {
-  uno = value;
-}
-
-function __setdue__(value) {
-  due = value;
-}
-
-function __getuno__() {
+__$Getters__['uno'] = function () {
   return uno;
-}
+};
 
-function __getdue__() {
-  return due;
-}
+__$Setters__['uno'] = function (value) {
+  uno = value;
+};
 
-function __resetuno__() {
+__$Resetters__['uno'] = function () {
   uno = _unoTemp;
-}
+};
 
-function __resetdue__() {
+__$Getters__['due'] = function () {
+  return due;
+};
+
+__$Setters__['due'] = function (value) {
+  due = value;
+};
+
+__$Resetters__['due'] = function () {
   due = _dueTemp;
-}
+};
 
-__$Getters__['uno'] = __getuno__;
-__$Setters__['uno'] = __setuno__;
-__$Resetters__['uno'] = __resetuno__;
-__$Getters__['due'] = __getdue__;
-__$Setters__['due'] = __setdue__;
-__$Resetters__['due'] = __resetdue__;
+export { __GetDependency__ };
+export { __GetDependency__ as __get__ };
+export { __Rewire__ };
+export { __Rewire__ as __set__ };
+export { __ResetDependency__ };

--- a/fixtures/requireExports/expected.js
+++ b/fixtures/requireExports/expected.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import _MyModuleTemp from 'path/to/MyModule.js';
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
@@ -17,7 +16,9 @@ function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
-let MyModule = _MyModuleTemp;
+let MyModule = require('MyModule');
+
+let _MyModule = MyModule;
 
 __$Getters__['MyModule'] = function () {
   return MyModule;
@@ -28,11 +29,16 @@ __$Setters__['MyModule'] = function (value) {
 };
 
 __$Resetters__['MyModule'] = function () {
-  MyModule = _MyModuleTemp;
+  MyModule = _MyModule;
 };
 
-export { __GetDependency__ };
-export { __GetDependency__ as __get__ };
-export { __Rewire__ };
-export { __Rewire__ as __set__ };
-export { __ResetDependency__ };
+function out(todo) {
+  return MyModule.something(todo);
+}
+
+module.exports = out;
+module.exports.__GetDependency__ = __GetDependency__;
+module.exports.__get__ = __GetDependency__;
+module.exports.__Rewire__ = __Rewire__;
+module.exports.__set__ = __Rewire__;
+module.exports.__ResetDependency__ = __ResetDependency__;

--- a/fixtures/requireExports/input.js
+++ b/fixtures/requireExports/input.js
@@ -1,0 +1,7 @@
+var MyModule = require('MyModule');
+
+function out(todo) {
+  return MyModule.something(todo);
+}
+
+module.exports = out;

--- a/fixtures/requireMultiExports/expected.js
+++ b/fixtures/requireMultiExports/expected.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import _MyModuleTemp from 'path/to/MyModule.js';
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
@@ -17,7 +16,9 @@ function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
-let MyModule = _MyModuleTemp;
+let MyModule = require('MyModule');
+
+let _MyModule = MyModule;
 
 __$Getters__['MyModule'] = function () {
   return MyModule;
@@ -28,11 +29,17 @@ __$Setters__['MyModule'] = function (value) {
 };
 
 __$Resetters__['MyModule'] = function () {
-  MyModule = _MyModuleTemp;
+  MyModule = _MyModule;
 };
 
-export { __GetDependency__ };
-export { __GetDependency__ as __get__ };
-export { __Rewire__ };
-export { __Rewire__ as __set__ };
-export { __ResetDependency__ };
+function out(todo) {
+  return MyModule.something(todo);
+}
+
+module.exports.out = out;
+module.exports.other = 'Foo';
+module.exports.__GetDependency__ = __GetDependency__;
+module.exports.__get__ = __GetDependency__;
+module.exports.__Rewire__ = __Rewire__;
+module.exports.__set__ = __Rewire__;
+module.exports.__ResetDependency__ = __ResetDependency__;

--- a/fixtures/requireMultiExports/input.js
+++ b/fixtures/requireMultiExports/input.js
@@ -1,0 +1,8 @@
+var MyModule = require('MyModule');
+
+function out(todo) {
+  return MyModule.something(todo);
+}
+
+module.exports.out = out;
+module.exports.other = 'Foo';

--- a/fixtures/topLevelVar/expected.js
+++ b/fixtures/topLevelVar/expected.js
@@ -1,0 +1,62 @@
+'use strict';
+
+let __$Getters__ = [];
+let __$Setters__ = [];
+let __$Resetters__ = [];
+
+function __GetDependency__(name) {
+  return __$Getters__[name]();
+}
+
+function __Rewire__(name, value) {
+  __$Setters__[name](value);
+}
+
+function __ResetDependency__(name) {
+  __$Resetters__[name]();
+}
+
+let MyModule = require('MyModule');
+
+let _MyModule = MyModule;
+
+__$Getters__['MyModule'] = function () {
+  return MyModule;
+};
+
+__$Setters__['MyModule'] = function (value) {
+  MyModule = value;
+};
+
+__$Resetters__['MyModule'] = function () {
+  MyModule = _MyModule;
+};
+
+let Temp,
+    Thing = MyModule.doDah;
+
+let _Thing = Thing;
+
+__$Getters__['Thing'] = function () {
+  return Thing;
+};
+
+__$Setters__['Thing'] = function (value) {
+  Thing = value;
+};
+
+__$Resetters__['Thing'] = function () {
+  Thing = _Thing;
+};
+
+function out(todo) {
+  var result = Thing.process(todo);
+  return MyModule.something(result);
+}
+
+module.exports = out;
+module.exports.__GetDependency__ = __GetDependency__;
+module.exports.__get__ = __GetDependency__;
+module.exports.__Rewire__ = __Rewire__;
+module.exports.__set__ = __Rewire__;
+module.exports.__ResetDependency__ = __ResetDependency__;

--- a/fixtures/topLevelVar/input.js
+++ b/fixtures/topLevelVar/input.js
@@ -1,0 +1,10 @@
+var MyModule = require('MyModule');
+
+var Temp, Thing = MyModule.doDah;
+
+function out(todo) {
+  var result = Thing.process(todo);
+  return MyModule.something(result);
+}
+
+module.exports = out;

--- a/fixtures/wildcardImport/expected.js
+++ b/fixtures/wildcardImport/expected.js
@@ -1,12 +1,9 @@
 'use strict';
 
-export { __GetDependency__ };
-export { __Rewire__ };
-export { __ResetDependency__ };
 import * as _AllImportsTemp from 'path/to/LargeModules.js';
-var __$Getters__ = [];
-var __$Setters__ = [];
-var __$Resetters__ = [];
+let __$Getters__ = [];
+let __$Setters__ = [];
+let __$Resetters__ = [];
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
@@ -20,20 +17,22 @@ function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
-var AllImports = _AllImportsTemp;
+let AllImports = _AllImportsTemp;
 
-function __setAllImports__(value) {
-  AllImports = value;
-}
-
-function __getAllImports__() {
+__$Getters__['AllImports'] = function () {
   return AllImports;
-}
+};
 
-function __resetAllImports__() {
+__$Setters__['AllImports'] = function (value) {
+  AllImports = value;
+};
+
+__$Resetters__['AllImports'] = function () {
   AllImports = _AllImportsTemp;
-}
+};
 
-__$Getters__['AllImports'] = __getAllImports__;
-__$Setters__['AllImports'] = __setAllImports__;
-__$Resetters__['AllImports'] = __resetAllImports__;
+export { __GetDependency__ };
+export { __GetDependency__ as __get__ };
+export { __Rewire__ };
+export { __Rewire__ as __set__ };
+export { __ResetDependency__ };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-rewire",
-  "version": "0.1.5",
-  "description": "A babel plugin adding the ability to rewire modul dependency. This enables to mock modules for testing purposes.",
+  "version": "0.1.6",
+  "description": "A babel plugin adding the ability to rewire module dependencies. This enables to mock modules for testing purposes.",
   "main": "src/babel-plugin-rewire.js",
   "scripts": {
     "test": "./node_modules/.bin/mocha"

--- a/test/BabelRewirePluginTest.js
+++ b/test/BabelRewirePluginTest.js
@@ -36,7 +36,8 @@ describe('BabelRewirePluginTest', function() {
 		'multipleImportsWithAliases',
 		'wildcardImport',
 		'requireExports',
-		'requireMultiExports'
+		'requireMultiExports',
+		'topLevelVar'
 	];
 	
 	featuresToTest.forEach(function(feature) {

--- a/test/BabelRewirePluginTest.js
+++ b/test/BabelRewirePluginTest.js
@@ -8,7 +8,7 @@ describe('BabelRewirePluginTest', function() {
 
 	var babelTranslationOptions = {
 		blacklist: 'es6.modules',
-		whitelist: '',
+		whitelist: 'strict',
 		plugins: path.resolve(__dirname, '../src/babel-plugin-rewire.js')
 	};
 
@@ -34,7 +34,9 @@ describe('BabelRewirePluginTest', function() {
 		'defaultExportWithNamedFunction',
 		'multipleImports',
 		'multipleImportsWithAliases',
-		'wildcardImport'
+		'wildcardImport',
+		'requireExports',
+		'requireMultiExports'
 	];
 	
 	featuresToTest.forEach(function(feature) {


### PR DESCRIPTION
summary of changes:

* es6 module exports move to bottom
* es6 module exports only added if import or export is used
* `__set__` and `__get__` added to es6 module exports
* getter, setter and resetter functions inlined

* allows rewiring of vars declared with ```var <name> = require('module');```
* adds `__Rewire__`, `__GetDependency__`, `__ResetDependency__`, `__set__` and `__get__` to `module.exports` if no es6 module statements are used