### PR TITLE
Adding a fixture and broken test for module.exports

### DIFF
--- a/fixtures/transformation/defaultExport/expected.js
+++ b/fixtures/transformation/defaultExport/expected.js
@@ -36,23 +36,23 @@ let _defaultExport = "";
 Object.defineProperty(_defaultExport, "__Rewire__", {
   "value": __Rewire__,
   "enumberable": false
-})
+});
 Object.defineProperty(_defaultExport, "__set__", {
   "value": __Rewire__,
   "enumberable": false
-})
+});
 Object.defineProperty(_defaultExport, "__ResetDependency__", {
   "value": __ResetDependency__,
   "enumberable": false
-})
+});
 Object.defineProperty(_defaultExport, "__GetDependency__", {
   "value": __GetDependency__,
   "enumberable": false
-})
+});
 Object.defineProperty(_defaultExport, "__get__", {
   "value": __GetDependency__,
   "enumberable": false
-})
+});
 export default _defaultExport;
 export { __GetDependency__ };
 export { __GetDependency__ as __get__ };

--- a/fixtures/transformation/defaultExportWithClass/expected.js
+++ b/fixtures/transformation/defaultExportWithClass/expected.js
@@ -46,23 +46,23 @@ let _defaultExport = EclipseClient;
 Object.defineProperty(_defaultExport, '__Rewire__', {
     'value': __Rewire__,
     'enumberable': false
-})
+});
 Object.defineProperty(_defaultExport, '__set__', {
     'value': __Rewire__,
     'enumberable': false
-})
+});
 Object.defineProperty(_defaultExport, '__ResetDependency__', {
     'value': __ResetDependency__,
     'enumberable': false
-})
+});
 Object.defineProperty(_defaultExport, '__GetDependency__', {
     'value': __GetDependency__,
     'enumberable': false
-})
+});
 Object.defineProperty(_defaultExport, '__get__', {
     'value': __GetDependency__,
     'enumberable': false
-})
+});
 export default _defaultExport;
 export { __GetDependency__ };
 export { __GetDependency__ as __get__ };

--- a/fixtures/transformation/defaultExportWithNamedFunction/expected.js
+++ b/fixtures/transformation/defaultExportWithNamedFunction/expected.js
@@ -39,23 +39,23 @@ let _defaultExport = helloWorld;
 Object.defineProperty(_defaultExport, "__Rewire__", {
 	"value": __Rewire__,
 	"enumberable": false
-})
+});
 Object.defineProperty(_defaultExport, "__set__", {
 	"value": __Rewire__,
 	"enumberable": false
-})
+});
 Object.defineProperty(_defaultExport, "__ResetDependency__", {
 	"value": __ResetDependency__,
 	"enumberable": false
-})
+});
 Object.defineProperty(_defaultExport, "__GetDependency__", {
 	"value": __GetDependency__,
 	"enumberable": false
-})
+});
 Object.defineProperty(_defaultExport, "__get__", {
 	"value": __GetDependency__,
 	"enumberable": false
-})
+});
 export default _defaultExport;
 export { __GetDependency__ };
 export { __GetDependency__ as __get__ };

--- a/fixtures/transformation/issue16/expected.js
+++ b/fixtures/transformation/issue16/expected.js
@@ -376,8 +376,23 @@ module.exports = {
   EmailInput: EmailInput,
   URLInput: URLInput
 };
-module.exports.__GetDependency__ = __GetDependency__;
-module.exports.__get__ = __GetDependency__;
-module.exports.__Rewire__ = __Rewire__;
-module.exports.__set__ = __Rewire__;
-module.exports.__ResetDependency__ = __ResetDependency__;
+Object.defineProperty(module.exports, '__Rewire__', {
+  'value': __Rewire__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__set__', {
+  'value': __Rewire__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__ResetDependency__', {
+  'value': __ResetDependency__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__GetDependency__', {
+  'value': __GetDependency__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__get__', {
+  'value': __GetDependency__,
+  'enumberable': false
+});

--- a/fixtures/transformation/issuePathReplaceWith/expected.js
+++ b/fixtures/transformation/issuePathReplaceWith/expected.js
@@ -42,23 +42,23 @@ let _defaultExport = createSingleFieldValidatorFactory(requiredValidatorFunction
 Object.defineProperty(_defaultExport, '__Rewire__', {
 	'value': __Rewire__,
 	'enumberable': false
-})
+});
 Object.defineProperty(_defaultExport, '__set__', {
 	'value': __Rewire__,
 	'enumberable': false
-})
+});
 Object.defineProperty(_defaultExport, '__ResetDependency__', {
 	'value': __ResetDependency__,
 	'enumberable': false
-})
+});
 Object.defineProperty(_defaultExport, '__GetDependency__', {
 	'value': __GetDependency__,
 	'enumberable': false
-})
+});
 Object.defineProperty(_defaultExport, '__get__', {
 	'value': __GetDependency__,
 	'enumberable': false
-})
+});
 export default _defaultExport;
 export { __GetDependency__ };
 export { __GetDependency__ as __get__ };

--- a/fixtures/transformation/moduleExports/expected.js
+++ b/fixtures/transformation/moduleExports/expected.js
@@ -19,25 +19,23 @@ function __ResetDependency__(name) {
 module.exports = {
   foo: 'bar'
 };
-
 Object.defineProperty(module.exports, '__Rewire__', {
   'value': __Rewire__,
   'enumberable': false
-})
+});
 Object.defineProperty(module.exports, '__set__', {
   'value': __Rewire__,
   'enumberable': false
-})
+});
 Object.defineProperty(module.exports, '__ResetDependency__', {
   'value': __ResetDependency__,
   'enumberable': false
-})
+});
 Object.defineProperty(module.exports, '__GetDependency__', {
   'value': __GetDependency__,
   'enumberable': false
-})
+});
 Object.defineProperty(module.exports, '__get__', {
   'value': __GetDependency__,
   'enumberable': false
-})
-
+});

--- a/fixtures/transformation/moduleExports/expected.js
+++ b/fixtures/transformation/moduleExports/expected.js
@@ -1,0 +1,43 @@
+'use strict';
+
+let __$Getters__ = [];
+let __$Setters__ = [];
+let __$Resetters__ = [];
+
+function __GetDependency__(name) {
+  return __$Getters__[name]();
+}
+
+function __Rewire__(name, value) {
+  __$Setters__[name](value);
+}
+
+function __ResetDependency__(name) {
+  __$Resetters__[name]();
+}
+
+module.exports = {
+  foo: 'bar'
+};
+
+Object.defineProperty(module.exports, '__Rewire__', {
+  'value': __Rewire__,
+  'enumberable': false
+})
+Object.defineProperty(module.exports, '__set__', {
+  'value': __Rewire__,
+  'enumberable': false
+})
+Object.defineProperty(module.exports, '__ResetDependency__', {
+  'value': __ResetDependency__,
+  'enumberable': false
+})
+Object.defineProperty(module.exports, '__GetDependency__', {
+  'value': __GetDependency__,
+  'enumberable': false
+})
+Object.defineProperty(module.exports, '__get__', {
+  'value': __GetDependency__,
+  'enumberable': false
+})
+

--- a/fixtures/transformation/moduleExports/input.js
+++ b/fixtures/transformation/moduleExports/input.js
@@ -1,0 +1,3 @@
+module.exports = {
+  foo: 'bar'
+};

--- a/fixtures/transformation/requireExports/expected.js
+++ b/fixtures/transformation/requireExports/expected.js
@@ -37,8 +37,23 @@ function out(todo) {
 }
 
 module.exports = out;
-module.exports.__GetDependency__ = __GetDependency__;
-module.exports.__get__ = __GetDependency__;
-module.exports.__Rewire__ = __Rewire__;
-module.exports.__set__ = __Rewire__;
-module.exports.__ResetDependency__ = __ResetDependency__;
+Object.defineProperty(module.exports, '__Rewire__', {
+  'value': __Rewire__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__set__', {
+  'value': __Rewire__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__ResetDependency__', {
+  'value': __ResetDependency__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__GetDependency__', {
+  'value': __GetDependency__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__get__', {
+  'value': __GetDependency__,
+  'enumberable': false
+});

--- a/fixtures/transformation/requireMultiExports/expected.js
+++ b/fixtures/transformation/requireMultiExports/expected.js
@@ -38,8 +38,23 @@ function out(todo) {
 
 module.exports.out = out;
 module.exports.other = 'Foo';
-module.exports.__GetDependency__ = __GetDependency__;
-module.exports.__get__ = __GetDependency__;
-module.exports.__Rewire__ = __Rewire__;
-module.exports.__set__ = __Rewire__;
-module.exports.__ResetDependency__ = __ResetDependency__;
+Object.defineProperty(module.exports, '__Rewire__', {
+  'value': __Rewire__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__set__', {
+  'value': __Rewire__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__ResetDependency__', {
+  'value': __ResetDependency__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__GetDependency__', {
+  'value': __GetDependency__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__get__', {
+  'value': __GetDependency__,
+  'enumberable': false
+});

--- a/fixtures/transformation/topLevelVar/expected.js
+++ b/fixtures/transformation/topLevelVar/expected.js
@@ -55,8 +55,23 @@ function out(todo) {
 }
 
 module.exports = out;
-module.exports.__GetDependency__ = __GetDependency__;
-module.exports.__get__ = __GetDependency__;
-module.exports.__Rewire__ = __Rewire__;
-module.exports.__set__ = __Rewire__;
-module.exports.__ResetDependency__ = __ResetDependency__;
+Object.defineProperty(module.exports, '__Rewire__', {
+  'value': __Rewire__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__set__', {
+  'value': __Rewire__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__ResetDependency__', {
+  'value': __ResetDependency__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__GetDependency__', {
+  'value': __GetDependency__,
+  'enumberable': false
+});
+Object.defineProperty(module.exports, '__get__', {
+  'value': __GetDependency__,
+  'enumberable': false
+});

--- a/samples/issue22/sample.js
+++ b/samples/issue22/sample.js
@@ -1,13 +1,20 @@
 'use strict'
 
 import SimpleObject from './src/SimpleObject';
+import ModuleExports from './src/ModuleExports';
 import expect from 'expect.js';
 
 describe('Function keys', function(){
 
-  it('should not be leaked', function(){
+  it('should not be leaked with default export', function(){
     let keys = Object.keys(SimpleObject);
     expect(keys).to.eql(['foo', 'bar']);
     expect(typeof (SimpleObject.__Rewire__)).to.be('function');
+  });
+
+  it('should not be leaked with module.exports', function(){
+    let keys = Object.keys(ModuleExports);
+    expect(keys).to.eql(['foo', 'bar']);
+    expect(typeof (ModuleExports.__Rewire__)).to.be('function');
   });
 });

--- a/samples/issue22/src/ModuleExports.js
+++ b/samples/issue22/src/ModuleExports.js
@@ -1,0 +1,4 @@
+module.exports = {
+  foo: 'foo',
+  bar: 'bar'
+};

--- a/src/babel-plugin-rewire.js
+++ b/src/babel-plugin-rewire.js
@@ -76,11 +76,11 @@ module.exports = function(pluginArguments) {
 							var moduleExports = t.memberExpression(t.identifier('module'), t.identifier('exports'), false);
 
 							exports = [
-								t.expressionStatement(t.assignmentExpression("=", t.memberExpression(moduleExports, universalGetter.id, false), universalGetter.id)),
-								t.expressionStatement(t.assignmentExpression("=", t.memberExpression(moduleExports, t.identifier('__get__'), false), universalGetter.id)),
-								t.expressionStatement(t.assignmentExpression("=", t.memberExpression(moduleExports, universalSetter.id, false), universalSetter.id)),
-								t.expressionStatement(t.assignmentExpression("=", t.memberExpression(moduleExports, t.identifier('__set__'), false), universalSetter.id)),
-								t.expressionStatement(t.assignmentExpression("=", t.memberExpression(moduleExports, universalResetter.id, false), universalResetter.id))
+								addNonEnumerableProperty(t, moduleExports, '__Rewire__', t.identifier('__Rewire__')),
+								addNonEnumerableProperty(t, moduleExports, '__set__', t.identifier('__Rewire__')),
+								addNonEnumerableProperty(t, moduleExports, '__ResetDependency__', t.identifier('__ResetDependency__')),
+								addNonEnumerableProperty(t, moduleExports, '__GetDependency__', t.identifier('__GetDependency__')),
+								addNonEnumerableProperty(t, moduleExports, '__get__', t.identifier('__GetDependency__'))
 							]
 						}
 						node.body.push.apply(node.body, exports);

--- a/src/babel-plugin-rewire.js
+++ b/src/babel-plugin-rewire.js
@@ -196,10 +196,10 @@ module.exports = function(pluginArguments) {
 }
 
 function addNonEnumerableProperty(t, objectIdentifier, propertyName, valueIdentifier) {
-	return t.callExpression(t.memberExpression(t.identifier('Object'), t.identifier('defineProperty')), [ objectIdentifier, t.literal(propertyName),  t.objectExpression([
+	return t.expressionStatement(t.callExpression(t.memberExpression(t.identifier('Object'), t.identifier('defineProperty')), [ objectIdentifier, t.literal(propertyName),  t.objectExpression([
 		t.property('init', t.literal('value'), valueIdentifier),
 		t.property('init', t.literal('enumberable'), t.literal(false))
-	])]);
+	])]));
 }
 
 function accessorsFor(variableName, originalVar) {

--- a/test/BabelRewirePluginTransformTest.js
+++ b/test/BabelRewirePluginTransformTest.js
@@ -52,6 +52,7 @@ describe('BabelRewirePluginTest', function() {
 		'defaultExportWithClass',
 		'defaultExportWithNamedFunction',
 		'issuePathReplaceWith',
+		'moduleExports',
 		'multipleImports',
 		'multipleImportsWithAliases',
 		'wildcardImport',
@@ -59,7 +60,7 @@ describe('BabelRewirePluginTest', function() {
 		'requireMultiExports',
 		'topLevelVar'
 	];
-	
+
 	featuresToTest.forEach(function(feature) {
 		it('test babel-plugin-rewire for ' + feature, testTranslation.bind(null, feature));
 	});


### PR DESCRIPTION
Adding a test case, fixture, and first step to fixing the module.exports non-enumerable transformation.

I noticed you had these expectation files in a specific folder. Matching the file structure and building off of the previous PR to try to fix it.

There are failing tests that probably need to be updated now that I changed this one but have to run out. I figure this is a good starting point and I will continue playing around with it if you don't get to it right away.