### PR TITLE
Fixes #48 Adds support for non default export of async functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,65 @@ describe('module default export test', function() {
 });
 ```
 
+## Handling of async functions
+
+Rewiring of async functions works as one would expect using the same API as for other rewires for both default exports and namned exports.
+
+### Example
+Asuming your imported module consits of the following.
+```js
+// api.js
+export default async function asyncApiDefault() {
+   return await asyncApi();
+};
+
+export async function asyncApi() {
+   return await api();
+};
+
+function api() {
+  // Some async API call
+  return Promise.resolve('API Response');
+};
+```
+
+### Test Code
+In your test you would use the default exported API-Object to rewire the function `asyncApiDefault` and `asyncApi` of the imported module like this.
+```js
+import { default as asyncApiDefault, asyncApi,  __RewireAPI__ as AsyncApiRewireAPI } from 'api.js';
+describe('async function export test', function() {
+ it('should be able to rewire default async function', function() {
+    return asyncApiDefault().then(response => {
+      expect(response).to.equal('API Response');
+
+      AsyncApiRewireAPI.__set__('asyncApi', function() {
+        return Promise.resolve('Mock API Response');
+      });
+
+      return asyncApiDefault().then(response => {
+        expect(response).to.equal('Mock API Response');
+        AsyncApiRewireAPI.__ResetDependency__('asyncApi');
+      });
+    });
+  });
+
+  it('should be able to rewire non default async function', function() {
+    return asyncApi().then(response => {
+      expect(response).to.equal('API Response');
+
+      AsyncApiRewireAPI.__set__('api', function() {
+        return Promise.resolve('Mock API Response');
+      });
+
+      return asyncApi().then(response => {
+        expect(response).to.equal('Mock API Response');
+        AsyncApiRewireAPI.__ResetDependency__('api');
+      });
+    });
+  });
+});
+```
+
 ## Installation
 
 ```

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   }],
   "license": "ISC",
   "devDependencies": {
+    "babel-runtime": "^5.8.20",
     "core-js": "^1.0.0",
     "expect.js": "^0.3.1",
     "mocha": "^2.2.4",

--- a/samples/issue48/sample.js
+++ b/samples/issue48/sample.js
@@ -1,0 +1,34 @@
+import { default as asyncFunctionDefault, asyncFunction,  __RewireAPI__ as AsyncFunctionRewireAPI  } from './src/AsyncFunction.js';
+import expect from 'expect.js';
+
+describe('Test for issue 48', function() {
+  it('should be able to rewire default async function', function() {
+    return asyncFunctionDefault().then(response => {
+      expect(response).to.equal(2);
+
+      AsyncFunctionRewireAPI.__set__('promiseFunction', function() {
+        return Promise.resolve(3);
+      });
+
+      return asyncFunctionDefault().then(response => {
+        expect(response).to.equal(3);
+        AsyncFunctionRewireAPI.__ResetDependency__('promiseFunction');
+      });
+    });
+  });
+
+  it('should be able to rewire non default async function', function() {
+    return asyncFunction().then(response => {
+      expect(response).to.equal(2);
+
+      AsyncFunctionRewireAPI.__set__('promiseFunction', function() {
+        return Promise.resolve(3);
+      });
+
+      return asyncFunction().then(response => {
+        expect(response).to.equal(3);
+        AsyncFunctionRewireAPI.__ResetDependency__('promiseFunction');
+      });
+    });
+  });
+});

--- a/samples/issue48/src/AsyncFunction.js
+++ b/samples/issue48/src/AsyncFunction.js
@@ -1,0 +1,11 @@
+export default async function asyncFunctionDefault() {
+	return await promiseFunction();
+};
+
+export async function asyncFunction() {
+	return await promiseFunction();
+};
+
+function promiseFunction() {
+  return Promise.resolve(2);
+};

--- a/src/babel-plugin-rewire.js
+++ b/src/babel-plugin-rewire.js
@@ -213,7 +213,7 @@ module.exports = function(pluginArguments) {
 				var replacedFunctionDeclarationIdentifier = noRewire(scope.generateUidIdentifier(declaration.id.name + 'Orig'));
 				var originalFunctionIdentifier = declaration.id;
 				originalFunctionIdentifier.functionIdentifier = true;
-				var replacedFunctionDeclaration = t.functionDeclaration(replacedFunctionDeclarationIdentifier, declaration.params, declaration.body, declaration.generator, declaration.expression);
+				var replacedFunctionDeclaration = t.functionDeclaration(replacedFunctionDeclarationIdentifier, declaration.params, declaration.body, declaration.generator, declaration.async, declaration.expression);
 
 				var newFuntionDeclaration = [replacedFunctionDeclaration, t.variableDeclaration('var', [t.variableDeclarator(originalFunctionIdentifier, replacedFunctionDeclarationIdentifier)])];
 

--- a/usage-tests/BabelRewirePluginUsageTest.js
+++ b/usage-tests/BabelRewirePluginUsageTest.js
@@ -14,6 +14,7 @@ function transformSampleCodeToTestWithBabelPluginRewire(source, filename) {
 	var babelTransformationOptions = {
 		plugins: path.resolve(__dirname, '../src/babel-plugin-rewire.js'),
 		optional:[
+			'runtime',
 			'es6.spec.blockScoping',
 			'es6.spec.symbols',
 			'es6.spec.templateLiterals'
@@ -40,6 +41,7 @@ require('../samples/issue28/sample.js');
 require('../samples/issue29/sample.js');
 require('../samples/issue30/sample.js');
 require('../samples/issue33/sample.js');
+require('../samples/issue48/sample.js');
 require('../samples/functionRewireScope/sample.js');
 require('../samples/namedExportsRewire/sample.js');
 require('../samples/namedExportRewireSupport/sample.js');


### PR DESCRIPTION
The problem was that async was not carried over when creating the temporary function declaration.

Along with the fix is a new set of tests that verifies that it's possible to rewire async functions. Default exported async functions worked before this fix but not non default as mentioned in #48. 

I have also added `babel-runtime` to the dependencies to make it possible to run async functions.