### PR TITLE
Add in a special comment before all of the generated functions so that Istanbul will ignore those functions for code coverage purposes.

### DIFF
--- a/fixtures/transformation/babelissue1315/expected.js
+++ b/fixtures/transformation/babelissue1315/expected.js
@@ -27,19 +27,25 @@ import _UserModelTemp from 'models/user';
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
 	return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
 	__$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
 	__$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
 	'__GetDependency__': __GetDependency__,
 	'__get__': __GetDependency__,
@@ -48,42 +54,57 @@ let __RewireAPI__ = {
 	'__ResetDependency__': __ResetDependency__
 };
 let $ = _$Temp;
+/* istanbul ignore next */
 
 __$Getters__['$'] = function () {
 	return $;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['$'] = function (value) {
 	$ = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['$'] = function () {
 	$ = _$Temp;
 };
 
 let ie8Icons = _ie8IconsTemp;
+/* istanbul ignore next */
 
 __$Getters__['ie8Icons'] = function () {
 	return ie8Icons;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['ie8Icons'] = function (value) {
 	ie8Icons = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['ie8Icons'] = function () {
 	ie8Icons = _ie8IconsTemp;
 };
 
 let UserModel = _UserModelTemp;
+/* istanbul ignore next */
 
 __$Getters__['UserModel'] = function () {
 	return UserModel;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['UserModel'] = function (value) {
 	UserModel = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['UserModel'] = function () {
 	UserModel = _UserModelTemp;
@@ -92,14 +113,19 @@ __$Resetters__['UserModel'] = function () {
 let a = 'b';
 
 let _a = a;
+/* istanbul ignore next */
 
 __$Getters__['a'] = function () {
 	return a;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['a'] = function (value) {
 	a = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['a'] = function () {
 	a = _a;
@@ -107,14 +133,19 @@ __$Resetters__['a'] = function () {
 
 let user = UserModel.getCurrent();
 let _user = user;
+/* istanbul ignore next */
 
 __$Getters__['user'] = function () {
 	return user;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['user'] = function (value) {
 	user = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['user'] = function () {
 	user = _user;
@@ -124,14 +155,19 @@ let moduleName = user && user.inState('activated') ? 'inside' : 'outside';
 
 // Main app entryPoint
 let _moduleName = moduleName;
+/* istanbul ignore next */
 
 __$Getters__['moduleName'] = function () {
 	return moduleName;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['moduleName'] = function (value) {
 	moduleName = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['moduleName'] = function () {
 	moduleName = _moduleName;

--- a/fixtures/transformation/defaultExport/expected.js
+++ b/fixtures/transformation/defaultExport/expected.js
@@ -5,19 +5,25 @@ import _MyModuleTemp from 'path/to/MyModule.js';
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
   __$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
   "__GetDependency__": __GetDependency__,
   "__get__": __GetDependency__,
@@ -26,14 +32,19 @@ let __RewireAPI__ = {
   "__ResetDependency__": __ResetDependency__
 };
 let MyModule = _MyModuleTemp;
+/* istanbul ignore next */
 
 __$Getters__["MyModule"] = function () {
   return MyModule;
 };
 
+/* istanbul ignore next */
+
 __$Setters__["MyModule"] = function (value) {
   MyModule = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__["MyModule"] = function () {
   MyModule = _MyModuleTemp;

--- a/fixtures/transformation/defaultExportWithClass/expected.js
+++ b/fixtures/transformation/defaultExportWithClass/expected.js
@@ -5,19 +5,25 @@ import _fetchTemp from 'isomorphic-fetch';
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
     return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
     __$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
     __$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
     '__GetDependency__': __GetDependency__,
     '__get__': __GetDependency__,
@@ -26,14 +32,19 @@ let __RewireAPI__ = {
     '__ResetDependency__': __ResetDependency__
 };
 let fetch = _fetchTemp;
+/* istanbul ignore next */
 
 __$Getters__['fetch'] = function () {
     return fetch;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['fetch'] = function (value) {
     fetch = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['fetch'] = function () {
     fetch = _fetchTemp;

--- a/fixtures/transformation/defaultExportWithNamedFunction/expected.js
+++ b/fixtures/transformation/defaultExportWithNamedFunction/expected.js
@@ -6,19 +6,25 @@ var helloWorld = _helloWorldOrig;
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
 	return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
 	__$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
 	__$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
 	"__GetDependency__": __GetDependency__,
 	"__get__": __GetDependency__,
@@ -27,14 +33,19 @@ let __RewireAPI__ = {
 	"__ResetDependency__": __ResetDependency__
 };
 let myDependency = _myDependencyTemp;
+/* istanbul ignore next */
 
 __$Getters__["myDependency"] = function () {
 	return myDependency;
 };
 
+/* istanbul ignore next */
+
 __$Setters__["myDependency"] = function (value) {
 	myDependency = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__["myDependency"] = function () {
 	myDependency = _myDependencyTemp;
@@ -45,14 +56,19 @@ function _helloWorldOrig() {
 }
 
 var _helloWorld = helloWorld;
+/* istanbul ignore next */
 
 __$Getters__["helloWorld"] = function () {
 	return helloWorld;
 };
 
+/* istanbul ignore next */
+
 __$Setters__["helloWorld"] = function (value) {
 	helloWorld = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__["helloWorld"] = function () {
 	helloWorld = _helloWorld;

--- a/fixtures/transformation/defaultExportWithObject/expected.js
+++ b/fixtures/transformation/defaultExportWithObject/expected.js
@@ -3,19 +3,25 @@
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
 	return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
 	__$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
 	__$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
 	"__GetDependency__": __GetDependency__,
 	"__get__": __GetDependency__,

--- a/fixtures/transformation/defaultImport/expected.js
+++ b/fixtures/transformation/defaultImport/expected.js
@@ -4,19 +4,25 @@ import _MyModuleTemp from 'path/to/MyModule.js';
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
   __$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
   '__GetDependency__': __GetDependency__,
   '__get__': __GetDependency__,
@@ -25,14 +31,19 @@ let __RewireAPI__ = {
   '__ResetDependency__': __ResetDependency__
 };
 let MyModule = _MyModuleTemp;
+/* istanbul ignore next */
 
 __$Getters__['MyModule'] = function () {
   return MyModule;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['MyModule'] = function (value) {
   MyModule = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['MyModule'] = function () {
   MyModule = _MyModuleTemp;

--- a/fixtures/transformation/forOf/expected.js
+++ b/fixtures/transformation/forOf/expected.js
@@ -6,19 +6,25 @@ import _expectTemp from 'expect.js';
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
 	return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
 	__$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
 	__$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
 	'__GetDependency__': __GetDependency__,
 	'__get__': __GetDependency__,
@@ -27,28 +33,38 @@ let __RewireAPI__ = {
 	'__ResetDependency__': __ResetDependency__
 };
 let ComponentToTest = _ComponentToTestTemp;
+/* istanbul ignore next */
 
 __$Getters__['ComponentToTest'] = function () {
 	return ComponentToTest;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['ComponentToTest'] = function (value) {
 	ComponentToTest = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['ComponentToTest'] = function () {
 	ComponentToTest = _ComponentToTestTemp;
 };
 
 let expect = _expectTemp;
+/* istanbul ignore next */
 
 __$Getters__['expect'] = function () {
 	return expect;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['expect'] = function (value) {
 	expect = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['expect'] = function () {
 	expect = _expectTemp;

--- a/fixtures/transformation/functionRewireScope/expected.js
+++ b/fixtures/transformation/functionRewireScope/expected.js
@@ -4,19 +4,25 @@ var greet = _greetOrig;
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
 	return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
 	__$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
 	__$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
 	'__GetDependency__': __GetDependency__,
 	'__get__': __GetDependency__,
@@ -27,14 +33,19 @@ let __RewireAPI__ = {
 let test = greet('world');
 
 let _test = test;
+/* istanbul ignore next */
 
 __$Getters__['test'] = function () {
 	return test;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['test'] = function (value) {
 	test = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['test'] = function () {
 	test = _test;
@@ -76,14 +87,19 @@ function _greetOrig(whoToGreet) {
 }
 
 var _greet = greet;
+/* istanbul ignore next */
 
 __$Getters__['greet'] = function () {
 	return greet;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['greet'] = function (value) {
 	greet = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['greet'] = function () {
 	greet = _greet;

--- a/fixtures/transformation/issue16/expected.js
+++ b/fixtures/transformation/issue16/expected.js
@@ -3,19 +3,25 @@
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
   __$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
   '__GetDependency__': __GetDependency__,
   '__get__': __GetDependency__,
@@ -25,14 +31,19 @@ let __RewireAPI__ = {
 };
 var React = require('react/addons');
 var _React = React;
+/* istanbul ignore next */
 
 __$Getters__['React'] = function () {
   return React;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['React'] = function (value) {
   React = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['React'] = function () {
   React = _React;
@@ -40,14 +51,19 @@ __$Resetters__['React'] = function () {
 
 var _ = require('lodash');
 var _2 = _;
+/* istanbul ignore next */
 
 __$Getters__['_'] = function () {
   return _;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['_'] = function (value) {
   _ = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['_'] = function () {
   _ = _2;
@@ -55,14 +71,19 @@ __$Resetters__['_'] = function () {
 
 var StyleSheet = require('react-style');
 var _StyleSheet = StyleSheet;
+/* istanbul ignore next */
 
 __$Getters__['StyleSheet'] = function () {
   return StyleSheet;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['StyleSheet'] = function (value) {
   StyleSheet = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['StyleSheet'] = function () {
   StyleSheet = _StyleSheet;
@@ -71,14 +92,19 @@ __$Resetters__['StyleSheet'] = function () {
 var cx = require('classnames');
 
 var _cx = cx;
+/* istanbul ignore next */
 
 __$Getters__['cx'] = function () {
   return cx;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['cx'] = function (value) {
   cx = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['cx'] = function () {
   cx = _cx;
@@ -87,14 +113,19 @@ __$Resetters__['cx'] = function () {
 var $ = require('vendor/jquery/semantic');
 
 var _$ = $;
+/* istanbul ignore next */
 
 __$Getters__['$'] = function () {
   return $;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['$'] = function (value) {
   $ = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['$'] = function () {
   $ = _$;
@@ -103,14 +134,19 @@ __$Resetters__['$'] = function () {
 var Style = require('style/index.js');
 
 var _Style = Style;
+/* istanbul ignore next */
 
 __$Getters__['Style'] = function () {
   return Style;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['Style'] = function (value) {
   Style = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['Style'] = function () {
   Style = _Style;
@@ -124,14 +160,19 @@ var {
 let PROTOCOLS = ['http://', 'https://', 'ftp://'];
 
 let _PROTOCOLS = PROTOCOLS;
+/* istanbul ignore next */
 
 __$Getters__['PROTOCOLS'] = function () {
   return PROTOCOLS;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['PROTOCOLS'] = function (value) {
   PROTOCOLS = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['PROTOCOLS'] = function () {
   PROTOCOLS = _PROTOCOLS;
@@ -140,14 +181,19 @@ __$Resetters__['PROTOCOLS'] = function () {
 let DEFAULT_PROTOCOL = 'http://';
 
 let _DEFAULT_PROTOCOL = DEFAULT_PROTOCOL;
+/* istanbul ignore next */
 
 __$Getters__['DEFAULT_PROTOCOL'] = function () {
   return DEFAULT_PROTOCOL;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['DEFAULT_PROTOCOL'] = function (value) {
   DEFAULT_PROTOCOL = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['DEFAULT_PROTOCOL'] = function () {
   DEFAULT_PROTOCOL = _DEFAULT_PROTOCOL;
@@ -155,14 +201,19 @@ __$Resetters__['DEFAULT_PROTOCOL'] = function () {
 
 var Mixins = require('./mixins.jsx');
 var _Mixins = Mixins;
+/* istanbul ignore next */
 
 __$Getters__['Mixins'] = function () {
   return Mixins;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['Mixins'] = function (value) {
   Mixins = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['Mixins'] = function () {
   Mixins = _Mixins;
@@ -175,38 +226,55 @@ var FormFieldMixin = Mixins.FormFieldMixin,
 var _FormFieldMixin = FormFieldMixin;
 var _InputMixin = InputMixin;
 var _TextInputMixin = TextInputMixin;
+/* istanbul ignore next */
 
 __$Getters__['FormFieldMixin'] = function () {
   return FormFieldMixin;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['FormFieldMixin'] = function (value) {
   FormFieldMixin = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['FormFieldMixin'] = function () {
   FormFieldMixin = _FormFieldMixin;
 };
 
+/* istanbul ignore next */
+
 __$Getters__['InputMixin'] = function () {
   return InputMixin;
 };
+
+/* istanbul ignore next */
 
 __$Setters__['InputMixin'] = function (value) {
   InputMixin = value;
 };
 
+/* istanbul ignore next */
+
 __$Resetters__['InputMixin'] = function () {
   InputMixin = _InputMixin;
 };
+
+/* istanbul ignore next */
 
 __$Getters__['TextInputMixin'] = function () {
   return TextInputMixin;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['TextInputMixin'] = function (value) {
   TextInputMixin = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['TextInputMixin'] = function () {
   TextInputMixin = _TextInputMixin;
@@ -222,14 +290,19 @@ var TextInput = React.createClass({
 });
 
 var _TextInput = TextInput;
+/* istanbul ignore next */
 
 __$Getters__['TextInput'] = function () {
   return TextInput;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['TextInput'] = function (value) {
   TextInput = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['TextInput'] = function () {
   TextInput = _TextInput;
@@ -249,14 +322,19 @@ var EmailInput = React.createClass({
 });
 
 var _EmailInput = EmailInput;
+/* istanbul ignore next */
 
 __$Getters__['EmailInput'] = function () {
   return EmailInput;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['EmailInput'] = function (value) {
   EmailInput = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['EmailInput'] = function () {
   EmailInput = _EmailInput;
@@ -282,14 +360,19 @@ var URLInput = React.createClass({
 });
 
 var _URLInput = URLInput;
+/* istanbul ignore next */
 
 __$Getters__['URLInput'] = function () {
   return URLInput;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['URLInput'] = function (value) {
   URLInput = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['URLInput'] = function () {
   URLInput = _URLInput;
@@ -300,14 +383,19 @@ var textAreaStyle = StyleSheet.create({
 });
 
 var _textAreaStyle = textAreaStyle;
+/* istanbul ignore next */
 
 __$Getters__['textAreaStyle'] = function () {
   return textAreaStyle;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['textAreaStyle'] = function (value) {
   textAreaStyle = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['textAreaStyle'] = function () {
   textAreaStyle = _textAreaStyle;
@@ -338,14 +426,19 @@ var TextArea = React.createClass({
 });
 
 var _TextArea = TextArea;
+/* istanbul ignore next */
 
 __$Getters__['TextArea'] = function () {
   return TextArea;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['TextArea'] = function (value) {
   TextArea = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['TextArea'] = function () {
   TextArea = _TextArea;
@@ -363,14 +456,19 @@ var HiddenTextInput = React.createClass({
 });
 
 var _HiddenTextInput = HiddenTextInput;
+/* istanbul ignore next */
 
 __$Getters__['HiddenTextInput'] = function () {
   return HiddenTextInput;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['HiddenTextInput'] = function (value) {
   HiddenTextInput = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['HiddenTextInput'] = function () {
   HiddenTextInput = _HiddenTextInput;

--- a/fixtures/transformation/issuePathReplaceWith/expected.js
+++ b/fixtures/transformation/issuePathReplaceWith/expected.js
@@ -6,19 +6,25 @@ var requiredValidatorFunction = _requiredValidatorFunctionOrig;
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
 	return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
 	__$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
 	__$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
 	'__GetDependency__': __GetDependency__,
 	'__get__': __GetDependency__,
@@ -27,14 +33,19 @@ let __RewireAPI__ = {
 	'__ResetDependency__': __ResetDependency__
 };
 let createSingleFieldValidatorFactory = _createSingleFieldValidatorFactoryTemp;
+/* istanbul ignore next */
 
 __$Getters__['createSingleFieldValidatorFactory'] = function () {
 	return createSingleFieldValidatorFactory;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['createSingleFieldValidatorFactory'] = function (value) {
 	createSingleFieldValidatorFactory = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['createSingleFieldValidatorFactory'] = function () {
 	createSingleFieldValidatorFactory = _createSingleFieldValidatorFactoryTemp;
@@ -45,14 +56,19 @@ function _requiredValidatorFunctionOrig(translatedFieldLabel, fieldValue) {
 }
 
 var _requiredValidatorFunction = requiredValidatorFunction;
+/* istanbul ignore next */
 
 __$Getters__['requiredValidatorFunction'] = function () {
 	return requiredValidatorFunction;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['requiredValidatorFunction'] = function (value) {
 	requiredValidatorFunction = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['requiredValidatorFunction'] = function () {
 	requiredValidatorFunction = _requiredValidatorFunction;

--- a/fixtures/transformation/moduleExports/expected.js
+++ b/fixtures/transformation/moduleExports/expected.js
@@ -3,19 +3,25 @@
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
   __$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
   '__GetDependency__': __GetDependency__,
   '__get__': __GetDependency__,

--- a/fixtures/transformation/multipleImports/expected.js
+++ b/fixtures/transformation/multipleImports/expected.js
@@ -4,19 +4,25 @@ import { first as _firstTemp, second as _secondTemp } from 'path/to/another/Larg
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
   __$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
   '__GetDependency__': __GetDependency__,
   '__get__': __GetDependency__,
@@ -26,26 +32,37 @@ let __RewireAPI__ = {
 };
 let first = _firstTemp;
 let second = _secondTemp;
+/* istanbul ignore next */
 
 __$Getters__['first'] = function () {
   return first;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['first'] = function (value) {
   first = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['first'] = function () {
   first = _firstTemp;
 };
 
+/* istanbul ignore next */
+
 __$Getters__['second'] = function () {
   return second;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['second'] = function (value) {
   second = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['second'] = function () {
   second = _secondTemp;

--- a/fixtures/transformation/multipleImportsWithAliases/expected.js
+++ b/fixtures/transformation/multipleImportsWithAliases/expected.js
@@ -4,19 +4,25 @@ import { first as _unoTemp, second as _dueTemp } from 'path/to/another/LargeModu
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
   __$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
   '__GetDependency__': __GetDependency__,
   '__get__': __GetDependency__,
@@ -26,26 +32,37 @@ let __RewireAPI__ = {
 };
 let uno = _unoTemp;
 let due = _dueTemp;
+/* istanbul ignore next */
 
 __$Getters__['uno'] = function () {
   return uno;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['uno'] = function (value) {
   uno = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['uno'] = function () {
   uno = _unoTemp;
 };
 
+/* istanbul ignore next */
+
 __$Getters__['due'] = function () {
   return due;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['due'] = function (value) {
   due = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['due'] = function () {
   due = _dueTemp;

--- a/fixtures/transformation/namedFunctionExport/expected.js
+++ b/fixtures/transformation/namedFunctionExport/expected.js
@@ -4,19 +4,25 @@ var namedFunction = _namedFunctionOrig;
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
 	return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
 	__$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
 	__$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
 	"__GetDependency__": __GetDependency__,
 	"__get__": __GetDependency__,
@@ -30,14 +36,19 @@ function _namedFunctionOrig(val) {
 }
 
 var _namedFunction = namedFunction;
+/* istanbul ignore next */
 
 __$Getters__["namedFunction"] = function () {
 	return namedFunction;
 };
 
+/* istanbul ignore next */
+
 __$Setters__["namedFunction"] = function (value) {
 	namedFunction = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__["namedFunction"] = function () {
 	namedFunction = _namedFunction;

--- a/fixtures/transformation/namedVariableExport/expected.js
+++ b/fixtures/transformation/namedVariableExport/expected.js
@@ -3,19 +3,25 @@
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
 	return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
 	__$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
 	__$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
 	"__GetDependency__": __GetDependency__,
 	"__get__": __GetDependency__,
@@ -32,26 +38,37 @@ let namedVariable = function (val) {
 
 let _namedVariable = namedVariable;
 let _namedVariable2 = namedVariable2;
+/* istanbul ignore next */
 
 __$Getters__["namedVariable"] = function () {
 	return namedVariable;
 };
 
+/* istanbul ignore next */
+
 __$Setters__["namedVariable"] = function (value) {
 	namedVariable = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__["namedVariable"] = function () {
 	namedVariable = _namedVariable;
 };
 
+/* istanbul ignore next */
+
 __$Getters__["namedVariable2"] = function () {
 	return namedVariable2;
 };
 
+/* istanbul ignore next */
+
 __$Setters__["namedVariable2"] = function (value) {
 	namedVariable2 = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__["namedVariable2"] = function () {
 	namedVariable2 = _namedVariable2;

--- a/fixtures/transformation/noDefaultExport/expected.js
+++ b/fixtures/transformation/noDefaultExport/expected.js
@@ -4,19 +4,25 @@ var foo = _fooOrig;
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
 	return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
 	__$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
 	__$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
 	"__GetDependency__": __GetDependency__,
 	"__get__": __GetDependency__,
@@ -30,14 +36,19 @@ function _fooOrig(val) {
 }
 
 var _foo = foo;
+/* istanbul ignore next */
 
 __$Getters__["foo"] = function () {
 	return foo;
 };
 
+/* istanbul ignore next */
+
 __$Setters__["foo"] = function (value) {
 	foo = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__["foo"] = function () {
 	foo = _foo;

--- a/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
+++ b/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
@@ -5,19 +5,25 @@ var addOne = _addOneOrig;
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
 	return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
 	__$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
 	__$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
 	"__GetDependency__": __GetDependency__,
 	"__get__": __GetDependency__,
@@ -31,14 +37,19 @@ function _generateOneOrig() {
 }
 
 var _generateOne = generateOne;
+/* istanbul ignore next */
 
 __$Getters__["generateOne"] = function () {
 	return generateOne;
 };
 
+/* istanbul ignore next */
+
 __$Setters__["generateOne"] = function (value) {
 	generateOne = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__["generateOne"] = function () {
 	generateOne = _generateOne;
@@ -49,14 +60,19 @@ function _addOneOrig(val) {
 }
 
 var _addOne = addOne;
+/* istanbul ignore next */
 
 __$Getters__["addOne"] = function () {
 	return addOne;
 };
 
+/* istanbul ignore next */
+
 __$Setters__["addOne"] = function (value) {
 	addOne = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__["addOne"] = function () {
 	addOne = _addOne;

--- a/fixtures/transformation/requireExports/expected.js
+++ b/fixtures/transformation/requireExports/expected.js
@@ -4,19 +4,25 @@ var out = _outOrig;
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
   __$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
   '__GetDependency__': __GetDependency__,
   '__get__': __GetDependency__,
@@ -27,14 +33,19 @@ let __RewireAPI__ = {
 var MyModule = require('MyModule');
 
 var _MyModule = MyModule;
+/* istanbul ignore next */
 
 __$Getters__['MyModule'] = function () {
   return MyModule;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['MyModule'] = function (value) {
   MyModule = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['MyModule'] = function () {
   MyModule = _MyModule;
@@ -45,14 +56,19 @@ function _outOrig(todo) {
 }
 
 var _out = out;
+/* istanbul ignore next */
 
 __$Getters__['out'] = function () {
   return out;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['out'] = function (value) {
   out = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['out'] = function () {
   out = _out;

--- a/fixtures/transformation/requireMultiExports/expected.js
+++ b/fixtures/transformation/requireMultiExports/expected.js
@@ -4,19 +4,25 @@ var out = _outOrig;
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
   __$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
   '__GetDependency__': __GetDependency__,
   '__get__': __GetDependency__,
@@ -27,14 +33,19 @@ let __RewireAPI__ = {
 var MyModule = require('MyModule');
 
 var _MyModule = MyModule;
+/* istanbul ignore next */
 
 __$Getters__['MyModule'] = function () {
   return MyModule;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['MyModule'] = function (value) {
   MyModule = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['MyModule'] = function () {
   MyModule = _MyModule;
@@ -45,14 +56,19 @@ function _outOrig(todo) {
 }
 
 var _out = out;
+/* istanbul ignore next */
 
 __$Getters__['out'] = function () {
   return out;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['out'] = function (value) {
   out = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['out'] = function () {
   out = _out;

--- a/fixtures/transformation/topLevelVar/expected.js
+++ b/fixtures/transformation/topLevelVar/expected.js
@@ -4,19 +4,25 @@ var out = _outOrig;
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
   __$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
   '__GetDependency__': __GetDependency__,
   '__get__': __GetDependency__,
@@ -27,14 +33,19 @@ let __RewireAPI__ = {
 var MyModule = require('MyModule');
 
 var _MyModule = MyModule;
+/* istanbul ignore next */
 
 __$Getters__['MyModule'] = function () {
   return MyModule;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['MyModule'] = function (value) {
   MyModule = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['MyModule'] = function () {
   MyModule = _MyModule;
@@ -44,14 +55,19 @@ var Temp,
     Thing = MyModule.doDah;
 
 var _Thing = Thing;
+/* istanbul ignore next */
 
 __$Getters__['Thing'] = function () {
   return Thing;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['Thing'] = function (value) {
   Thing = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['Thing'] = function () {
   Thing = _Thing;
@@ -63,14 +79,19 @@ function _outOrig(todo) {
 }
 
 var _out = out;
+/* istanbul ignore next */
 
 __$Getters__['out'] = function () {
   return out;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['out'] = function (value) {
   out = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['out'] = function () {
   out = _out;

--- a/fixtures/transformation/wildcardImport/expected.js
+++ b/fixtures/transformation/wildcardImport/expected.js
@@ -4,19 +4,25 @@ import * as _AllImportsTemp from 'path/to/LargeModules.js';
 let __$Getters__ = [];
 let __$Setters__ = [];
 let __$Resetters__ = [];
+/* istanbul ignore next */
 
 function __GetDependency__(name) {
   return __$Getters__[name]();
 }
 
+/* istanbul ignore next */
+
 function __Rewire__(name, value) {
   __$Setters__[name](value);
 }
+
+/* istanbul ignore next */
 
 function __ResetDependency__(name) {
   __$Resetters__[name]();
 }
 
+/* istanbul ignore next */
 let __RewireAPI__ = {
   '__GetDependency__': __GetDependency__,
   '__get__': __GetDependency__,
@@ -25,14 +31,19 @@ let __RewireAPI__ = {
   '__ResetDependency__': __ResetDependency__
 };
 let AllImports = _AllImportsTemp;
+/* istanbul ignore next */
 
 __$Getters__['AllImports'] = function () {
   return AllImports;
 };
 
+/* istanbul ignore next */
+
 __$Setters__['AllImports'] = function (value) {
   AllImports = value;
 };
+
+/* istanbul ignore next */
 
 __$Resetters__['AllImports'] = function () {
   AllImports = _AllImportsTemp;

--- a/src/babel-plugin-rewire.js
+++ b/src/babel-plugin-rewire.js
@@ -86,8 +86,19 @@ module.exports = function(pluginArguments) {
 						var settersArrayDeclaration = t.variableDeclaration('let', [t.variableDeclarator(noRewire(t.identifier("__$Setters__")), t.arrayExpression([]))]);
 						var resettersArrayDeclaration = t.variableDeclaration('let', [t.variableDeclarator(noRewire(t.identifier("__$Resetters__")), t.arrayExpression([]))]);
 
-						node.body.unshift(gettersArrayDeclaration, settersArrayDeclaration, resettersArrayDeclaration, universalGetter,
-							universalSetter, universalResetter, rewireAPIObject);
+						var istanbulIgnoreComment = createIstanbulIgnoreComment();
+
+						node.body.unshift(gettersArrayDeclaration, 
+								settersArrayDeclaration, 
+								resettersArrayDeclaration, 
+								istanbulIgnoreComment,
+								universalGetter,
+								istanbulIgnoreComment,
+								universalSetter, 
+								istanbulIgnoreComment,
+								universalResetter, 
+								istanbulIgnoreComment,
+								rewireAPIObject);
 
 						return node;
 					},
@@ -319,6 +330,10 @@ function addNonEnumerableProperty(t, objectIdentifier, propertyName, valueIdenti
 	])]));
 }
 
+function createIstanbulIgnoreComment() {
+	return t.identifier("/* istanbul ignore next */");
+}
+
 function accessorsFor(variableName, originalVar) {
 	var accessor = function(array, variableName, operation) {
 		return t.expressionStatement(t.assignmentExpression("=", t.memberExpression(array, t.literal(variableName), true), operation));
@@ -348,9 +363,14 @@ function accessorsFor(variableName, originalVar) {
 			])
 	);
 
+	var istanbulIgnoreComment = createIstanbulIgnoreComment();
+
 	return [
+		istanbulIgnoreComment,
 		accessor(t.identifier("__$Getters__"), variableName, getter),
+		istanbulIgnoreComment,
 		accessor(t.identifier("__$Setters__"), variableName, setter),
+		istanbulIgnoreComment,
 		accessor(t.identifier("__$Resetters__"), variableName, resetter)
 	];
 }


### PR DESCRIPTION
Add in a special comment before all of the generated functions so that Istanbul will ignore those functions for code coverage purposes.

This is because those functions are not part of the code that is being tested, and so it's not reasonable to expect coverage to look at them.