### PR TITLE
Handle default exports that are null

### DIFF
--- a/fixtures/transformation/defaultExport/expected.js
+++ b/fixtures/transformation/defaultExport/expected.js
@@ -41,7 +41,7 @@ __$Resetters__["MyModule"] = function () {
 
 let _defaultExport = "";
 
-if (typeof _defaultExport === "object" || typeof _defaultExport === "function") {
+if ((typeof _defaultExport === "object" || typeof _defaultExport === "function") && Object.isExtensible(_defaultExport)) {
   Object.defineProperty(_defaultExport, "__Rewire__", {
     "value": __Rewire__,
     "enumberable": false

--- a/fixtures/transformation/defaultExportWithClass/expected.js
+++ b/fixtures/transformation/defaultExportWithClass/expected.js
@@ -51,7 +51,7 @@ class EclipseClient {
 }
 let _defaultExport = EclipseClient;
 
-if (typeof _defaultExport === 'object' || typeof _defaultExport === 'function') {
+if ((typeof _defaultExport === 'object' || typeof _defaultExport === 'function') && Object.isExtensible(_defaultExport)) {
     Object.defineProperty(_defaultExport, '__Rewire__', {
         'value': __Rewire__,
         'enumberable': false

--- a/fixtures/transformation/defaultExportWithNamedFunction/expected.js
+++ b/fixtures/transformation/defaultExportWithNamedFunction/expected.js
@@ -60,7 +60,7 @@ __$Resetters__["helloWorld"] = function () {
 
 var _defaultExport = helloWorld;
 
-if (typeof _defaultExport === "object" || typeof _defaultExport === "function") {
+if ((typeof _defaultExport === "object" || typeof _defaultExport === "function") && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, "__Rewire__", {
 		"value": __Rewire__,
 		"enumberable": false

--- a/fixtures/transformation/defaultExportWithObject/expected.js
+++ b/fixtures/transformation/defaultExportWithObject/expected.js
@@ -29,7 +29,7 @@ let _defaultExport = {
 	}
 };
 
-if (typeof _defaultExport === "object" || typeof _defaultExport === "function") {
+if ((typeof _defaultExport === "object" || typeof _defaultExport === "function") && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, "__Rewire__", {
 		"value": __Rewire__,
 		"enumberable": false

--- a/fixtures/transformation/functionRewireScope/expected.js
+++ b/fixtures/transformation/functionRewireScope/expected.js
@@ -42,7 +42,7 @@ __$Resetters__['test'] = function () {
 
 let _defaultExport = test;
 
-if (typeof _defaultExport === 'object' || typeof _defaultExport === 'function') {
+if ((typeof _defaultExport === 'object' || typeof _defaultExport === 'function') && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, '__Rewire__', {
 		'value': __Rewire__,
 		'enumberable': false

--- a/fixtures/transformation/issuePathReplaceWith/expected.js
+++ b/fixtures/transformation/issuePathReplaceWith/expected.js
@@ -62,7 +62,7 @@ export { _requiredValidatorFunctionOrig as requiredValidatorFunction };
 
 let _defaultExport = createSingleFieldValidatorFactory(requiredValidatorFunction);
 
-if (typeof _defaultExport === 'object' || typeof _defaultExport === 'function') {
+if ((typeof _defaultExport === 'object' || typeof _defaultExport === 'function') && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, '__Rewire__', {
 		'value': __Rewire__,
 		'enumberable': false

--- a/fixtures/transformation/namedFunctionExport/expected.js
+++ b/fixtures/transformation/namedFunctionExport/expected.js
@@ -49,7 +49,7 @@ let _defaultExport = function (val) {
 	return namedFunction(val);
 };
 
-if (typeof _defaultExport === "object" || typeof _defaultExport === "function") {
+if ((typeof _defaultExport === "object" || typeof _defaultExport === "function") && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, "__Rewire__", {
 		"value": __Rewire__,
 		"enumberable": false

--- a/fixtures/transformation/namedVariableExport/expected.js
+++ b/fixtures/transformation/namedVariableExport/expected.js
@@ -64,7 +64,7 @@ let _defaultExport = function (val) {
 	return namedVariable(val) + namedVariable2(val);
 };
 
-if (typeof _defaultExport === "object" || typeof _defaultExport === "function") {
+if ((typeof _defaultExport === "object" || typeof _defaultExport === "function") && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, "__Rewire__", {
 		"value": __Rewire__,
 		"enumberable": false

--- a/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
+++ b/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
@@ -65,7 +65,7 @@ __$Resetters__["addOne"] = function () {
 export { _addOneOrig as addOne };
 let _defaultExport = 4;
 
-if (typeof _defaultExport === "object" || typeof _defaultExport === "function") {
+if ((typeof _defaultExport === "object" || typeof _defaultExport === "function") && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, "__Rewire__", {
 		"value": __Rewire__,
 		"enumberable": false

--- a/samples/defaultExportNonExtensible/sample.js
+++ b/samples/defaultExportNonExtensible/sample.js
@@ -1,0 +1,34 @@
+import Frozen from './src/Frozen';
+import NonExtensible from './src/NonExtensible';
+import Sealed from './src/Sealed';
+
+import expect from 'expect.js';
+
+/**
+ * If the Object.isExtensible() functionality didn't work,
+ * importing these would throw an error at runtime.
+ */
+import BooleanPrimitive from './src/Boolean';
+import Null from './src/Null';
+import NumberPrimitive from './src/Number';
+import StringPrimitive from './src/String';
+import Undefined from './src/Undefined';
+
+describe('Non-extensible default exports', () => {
+	it('Frozen values are not rewired', () => {
+		expect(Object.isFrozen(Frozen)).to.be(true);
+		expect(Object.isExtensible(Frozen)).to.be(false);
+		expect(Frozen.__Rewire__).to.be(undefined);
+	});
+
+	it('NonExtensible values are not rewired', () => {
+		expect(Object.isExtensible(NonExtensible)).to.be(false);
+		expect(NonExtensible.__Rewire__).to.be(undefined);
+	});
+
+	it('Sealed values are not rewired', () => {
+		expect(Object.isSealed(Sealed)).to.be(true);
+		expect(Object.isExtensible(Sealed)).to.be(false);
+		expect(Sealed.__Rewire__).to.be(undefined);
+	});
+});

--- a/samples/defaultExportNonExtensible/src/Boolean.js
+++ b/samples/defaultExportNonExtensible/src/Boolean.js
@@ -1,0 +1,1 @@
+export default true;

--- a/samples/defaultExportNonExtensible/src/Frozen.js
+++ b/samples/defaultExportNonExtensible/src/Frozen.js
@@ -1,0 +1,1 @@
+export default Object.freeze({});

--- a/samples/defaultExportNonExtensible/src/NonExtensible.js
+++ b/samples/defaultExportNonExtensible/src/NonExtensible.js
@@ -1,0 +1,1 @@
+export default Object.preventExtensions(() => {});

--- a/samples/defaultExportNonExtensible/src/Null.js
+++ b/samples/defaultExportNonExtensible/src/Null.js
@@ -1,0 +1,1 @@
+export default null;

--- a/samples/defaultExportNonExtensible/src/Number.js
+++ b/samples/defaultExportNonExtensible/src/Number.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/samples/defaultExportNonExtensible/src/Sealed.js
+++ b/samples/defaultExportNonExtensible/src/Sealed.js
@@ -1,0 +1,1 @@
+export default Object.seal({});

--- a/samples/defaultExportNonExtensible/src/String.js
+++ b/samples/defaultExportNonExtensible/src/String.js
@@ -1,0 +1,1 @@
+export default '';

--- a/samples/defaultExportNonExtensible/src/Undefined.js
+++ b/samples/defaultExportNonExtensible/src/Undefined.js
@@ -1,0 +1,1 @@
+export default undefined;

--- a/src/babel-plugin-rewire.js
+++ b/src/babel-plugin-rewire.js
@@ -288,9 +288,14 @@ module.exports = function(pluginArguments) {
 				])]));
 
 				var addAdditionalProperties = t.ifStatement(
-					t.logicalExpression('||',
-						t.binaryExpression('===', t.unaryExpression('typeof', defaultExportVariableId, true), t.literal('object')),
-						t.binaryExpression('===', t.unaryExpression('typeof', defaultExportVariableId, true), t.literal('function'))
+					t.logicalExpression('&&',
+						t.parenthesizedExpression(
+							t.logicalExpression('||',
+								t.binaryExpression('===', t.unaryExpression('typeof', defaultExportVariableId, true), t.literal('object')),
+								t.binaryExpression('===', t.unaryExpression('typeof', defaultExportVariableId, true), t.literal('function'))
+							)
+						),
+						t.callExpression(t.memberExpression(t.identifier('Object'), t.identifier('isExtensible')), [defaultExportVariableId])
 					),
 					t.blockStatement([
 						addNonEnumerableProperty(t, defaultExportVariableId, '__Rewire__', t.identifier('__Rewire__')),

--- a/usage-tests/BabelRewirePluginUsageTest.js
+++ b/usage-tests/BabelRewirePluginUsageTest.js
@@ -45,4 +45,5 @@ require('../samples/issue48/sample.js');
 require('../samples/functionRewireScope/sample.js');
 require('../samples/namedExportsRewire/sample.js');
 require('../samples/namedExportRewireSupport/sample.js');
+require('../samples/defaultExportNonExtensible/sample.js');
 hook.unhook('.js'); // removes your own transform


### PR DESCRIPTION
This changes fixes a bug where the code would fail at runtime if the default export of a module was `null`. While it's an odd use case, there are certainly situations where it's applicable (for instance, conditional compilation). The plugin ensures that the default export is an object before modifying it, but it forgets to check if the export is `null` (since `typeof null === 'object'`). This adds an additional check to ensure the export isn't also `null`.

Let me know if I haven't followed any conventions or if you'd like something updated.