### PR TITLE
Put temp files in their own temp plugin directory

### DIFF
--- a/test/BabelRewirePluginTransformTest.js
+++ b/test/BabelRewirePluginTransformTest.js
@@ -28,7 +28,13 @@ describe('BabelRewirePluginTest', function() {
 			expect().fail("Transformation failed: \n" + error.stack)
 		}
 
-		fs.writeFileSync('/tmp/testexpected' + testName + '.js', transformationOutput, 'utf-8');
+		var tempDir = '/tmp/babel-plugin-rewire';
+
+		try {
+			fs.mkdirSync(tempDir);
+		} catch(error) {}
+
+		fs.writeFileSync(tempDir + '/testexpected' + testName + '.js', transformationOutput, 'utf-8');
 
 		if(expected != transformationOutput) {
 			console.log(transformationOutput);
@@ -74,8 +80,4 @@ describe('BabelRewirePluginTest', function() {
 	featuresToTest.forEach(function(feature) {
 		it('test successful translation babel-plugin-rewire for ' + feature, testSuccessfulTranslation.bind(null, feature));
 	});
-
-
-
-
-	});
+});


### PR DESCRIPTION
Checking to see why tests were failing was a bit cumbersome since I already had a bunch of junk in the tmp directory. Turns out it was only because I have all files appended with a `\n` when saving.

If you think it would be more useful to add tests for checking a trimmed version of the transformed output let me know. I feel this wouldn't hurt either way.