### PR TITLE
make injected properties configurable; closes #61

### DIFF
--- a/fixtures/transformation/defaultExport/expected.js
+++ b/fixtures/transformation/defaultExport/expected.js
@@ -44,27 +44,33 @@ let _defaultExport = "";
 if ((typeof _defaultExport === "object" || typeof _defaultExport === "function") && Object.isExtensible(_defaultExport)) {
   Object.defineProperty(_defaultExport, "__Rewire__", {
     "value": __Rewire__,
-    "enumberable": false
+    "enumberable": false,
+    "configurable": true
   });
   Object.defineProperty(_defaultExport, "__set__", {
     "value": __Rewire__,
-    "enumberable": false
+    "enumberable": false,
+    "configurable": true
   });
   Object.defineProperty(_defaultExport, "__ResetDependency__", {
     "value": __ResetDependency__,
-    "enumberable": false
+    "enumberable": false,
+    "configurable": true
   });
   Object.defineProperty(_defaultExport, "__GetDependency__", {
     "value": __GetDependency__,
-    "enumberable": false
+    "enumberable": false,
+    "configurable": true
   });
   Object.defineProperty(_defaultExport, "__get__", {
     "value": __GetDependency__,
-    "enumberable": false
+    "enumberable": false,
+    "configurable": true
   });
   Object.defineProperty(_defaultExport, "__RewireAPI__", {
     "value": __RewireAPI__,
-    "enumberable": false
+    "enumberable": false,
+    "configurable": true
   });
 }
 

--- a/fixtures/transformation/defaultExportWithClass/expected.js
+++ b/fixtures/transformation/defaultExportWithClass/expected.js
@@ -54,27 +54,33 @@ let _defaultExport = EclipseClient;
 if ((typeof _defaultExport === 'object' || typeof _defaultExport === 'function') && Object.isExtensible(_defaultExport)) {
     Object.defineProperty(_defaultExport, '__Rewire__', {
         'value': __Rewire__,
-        'enumberable': false
+        'enumberable': false,
+        'configurable': true
     });
     Object.defineProperty(_defaultExport, '__set__', {
         'value': __Rewire__,
-        'enumberable': false
+        'enumberable': false,
+        'configurable': true
     });
     Object.defineProperty(_defaultExport, '__ResetDependency__', {
         'value': __ResetDependency__,
-        'enumberable': false
+        'enumberable': false,
+        'configurable': true
     });
     Object.defineProperty(_defaultExport, '__GetDependency__', {
         'value': __GetDependency__,
-        'enumberable': false
+        'enumberable': false,
+        'configurable': true
     });
     Object.defineProperty(_defaultExport, '__get__', {
         'value': __GetDependency__,
-        'enumberable': false
+        'enumberable': false,
+        'configurable': true
     });
     Object.defineProperty(_defaultExport, '__RewireAPI__', {
         'value': __RewireAPI__,
-        'enumberable': false
+        'enumberable': false,
+        'configurable': true
     });
 }
 

--- a/fixtures/transformation/defaultExportWithNamedFunction/expected.js
+++ b/fixtures/transformation/defaultExportWithNamedFunction/expected.js
@@ -63,27 +63,33 @@ var _defaultExport = helloWorld;
 if ((typeof _defaultExport === "object" || typeof _defaultExport === "function") && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, "__Rewire__", {
 		"value": __Rewire__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__set__", {
 		"value": __Rewire__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__ResetDependency__", {
 		"value": __ResetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__GetDependency__", {
 		"value": __GetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__get__", {
 		"value": __GetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__RewireAPI__", {
 		"value": __RewireAPI__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 }
 

--- a/fixtures/transformation/defaultExportWithObject/expected.js
+++ b/fixtures/transformation/defaultExportWithObject/expected.js
@@ -32,27 +32,33 @@ let _defaultExport = {
 if ((typeof _defaultExport === "object" || typeof _defaultExport === "function") && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, "__Rewire__", {
 		"value": __Rewire__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__set__", {
 		"value": __Rewire__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__ResetDependency__", {
 		"value": __ResetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__GetDependency__", {
 		"value": __GetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__get__", {
 		"value": __GetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__RewireAPI__", {
 		"value": __RewireAPI__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 }
 

--- a/fixtures/transformation/functionRewireScope/expected.js
+++ b/fixtures/transformation/functionRewireScope/expected.js
@@ -45,27 +45,33 @@ let _defaultExport = test;
 if ((typeof _defaultExport === 'object' || typeof _defaultExport === 'function') && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, '__Rewire__', {
 		'value': __Rewire__,
-		'enumberable': false
+		'enumberable': false,
+		'configurable': true
 	});
 	Object.defineProperty(_defaultExport, '__set__', {
 		'value': __Rewire__,
-		'enumberable': false
+		'enumberable': false,
+		'configurable': true
 	});
 	Object.defineProperty(_defaultExport, '__ResetDependency__', {
 		'value': __ResetDependency__,
-		'enumberable': false
+		'enumberable': false,
+		'configurable': true
 	});
 	Object.defineProperty(_defaultExport, '__GetDependency__', {
 		'value': __GetDependency__,
-		'enumberable': false
+		'enumberable': false,
+		'configurable': true
 	});
 	Object.defineProperty(_defaultExport, '__get__', {
 		'value': __GetDependency__,
-		'enumberable': false
+		'enumberable': false,
+		'configurable': true
 	});
 	Object.defineProperty(_defaultExport, '__RewireAPI__', {
 		'value': __RewireAPI__,
-		'enumberable': false
+		'enumberable': false,
+		'configurable': true
 	});
 }
 

--- a/fixtures/transformation/issue16/expected.js
+++ b/fixtures/transformation/issue16/expected.js
@@ -387,26 +387,32 @@ module.exports = {
 if (typeof module.exports === 'object' || typeof module.exports === 'function') {
   Object.defineProperty(module.exports, '__Rewire__', {
     'value': __Rewire__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__set__', {
     'value': __Rewire__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__ResetDependency__', {
     'value': __ResetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__GetDependency__', {
     'value': __GetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__get__', {
     'value': __GetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__RewireAPI__', {
     'value': __RewireAPI__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
 }

--- a/fixtures/transformation/issuePathReplaceWith/expected.js
+++ b/fixtures/transformation/issuePathReplaceWith/expected.js
@@ -65,27 +65,33 @@ let _defaultExport = createSingleFieldValidatorFactory(requiredValidatorFunction
 if ((typeof _defaultExport === 'object' || typeof _defaultExport === 'function') && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, '__Rewire__', {
 		'value': __Rewire__,
-		'enumberable': false
+		'enumberable': false,
+		'configurable': true
 	});
 	Object.defineProperty(_defaultExport, '__set__', {
 		'value': __Rewire__,
-		'enumberable': false
+		'enumberable': false,
+		'configurable': true
 	});
 	Object.defineProperty(_defaultExport, '__ResetDependency__', {
 		'value': __ResetDependency__,
-		'enumberable': false
+		'enumberable': false,
+		'configurable': true
 	});
 	Object.defineProperty(_defaultExport, '__GetDependency__', {
 		'value': __GetDependency__,
-		'enumberable': false
+		'enumberable': false,
+		'configurable': true
 	});
 	Object.defineProperty(_defaultExport, '__get__', {
 		'value': __GetDependency__,
-		'enumberable': false
+		'enumberable': false,
+		'configurable': true
 	});
 	Object.defineProperty(_defaultExport, '__RewireAPI__', {
 		'value': __RewireAPI__,
-		'enumberable': false
+		'enumberable': false,
+		'configurable': true
 	});
 }
 

--- a/fixtures/transformation/moduleExports/expected.js
+++ b/fixtures/transformation/moduleExports/expected.js
@@ -30,26 +30,32 @@ module.exports = {
 if (typeof module.exports === 'object' || typeof module.exports === 'function') {
   Object.defineProperty(module.exports, '__Rewire__', {
     'value': __Rewire__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__set__', {
     'value': __Rewire__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__ResetDependency__', {
     'value': __ResetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__GetDependency__', {
     'value': __GetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__get__', {
     'value': __GetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__RewireAPI__', {
     'value': __RewireAPI__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
 }

--- a/fixtures/transformation/namedFunctionExport/expected.js
+++ b/fixtures/transformation/namedFunctionExport/expected.js
@@ -52,27 +52,33 @@ let _defaultExport = function (val) {
 if ((typeof _defaultExport === "object" || typeof _defaultExport === "function") && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, "__Rewire__", {
 		"value": __Rewire__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__set__", {
 		"value": __Rewire__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__ResetDependency__", {
 		"value": __ResetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__GetDependency__", {
 		"value": __GetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__get__", {
 		"value": __GetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__RewireAPI__", {
 		"value": __RewireAPI__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 }
 

--- a/fixtures/transformation/namedVariableExport/expected.js
+++ b/fixtures/transformation/namedVariableExport/expected.js
@@ -67,27 +67,33 @@ let _defaultExport = function (val) {
 if ((typeof _defaultExport === "object" || typeof _defaultExport === "function") && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, "__Rewire__", {
 		"value": __Rewire__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__set__", {
 		"value": __Rewire__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__ResetDependency__", {
 		"value": __ResetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__GetDependency__", {
 		"value": __GetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__get__", {
 		"value": __GetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__RewireAPI__", {
 		"value": __RewireAPI__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 }
 

--- a/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
+++ b/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
@@ -68,27 +68,33 @@ let _defaultExport = 4;
 if ((typeof _defaultExport === "object" || typeof _defaultExport === "function") && Object.isExtensible(_defaultExport)) {
 	Object.defineProperty(_defaultExport, "__Rewire__", {
 		"value": __Rewire__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__set__", {
 		"value": __Rewire__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__ResetDependency__", {
 		"value": __ResetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__GetDependency__", {
 		"value": __GetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__get__", {
 		"value": __GetDependency__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 	Object.defineProperty(_defaultExport, "__RewireAPI__", {
 		"value": __RewireAPI__,
-		"enumberable": false
+		"enumberable": false,
+		"configurable": true
 	});
 }
 

--- a/fixtures/transformation/requireExports/expected.js
+++ b/fixtures/transformation/requireExports/expected.js
@@ -63,26 +63,32 @@ module.exports = out;
 if (typeof module.exports === 'object' || typeof module.exports === 'function') {
   Object.defineProperty(module.exports, '__Rewire__', {
     'value': __Rewire__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__set__', {
     'value': __Rewire__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__ResetDependency__', {
     'value': __ResetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__GetDependency__', {
     'value': __GetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__get__', {
     'value': __GetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__RewireAPI__', {
     'value': __RewireAPI__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
 }

--- a/fixtures/transformation/requireMultiExports/expected.js
+++ b/fixtures/transformation/requireMultiExports/expected.js
@@ -64,26 +64,32 @@ module.exports.other = 'Foo';
 if (typeof module.exports === 'object' || typeof module.exports === 'function') {
   Object.defineProperty(module.exports, '__Rewire__', {
     'value': __Rewire__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__set__', {
     'value': __Rewire__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__ResetDependency__', {
     'value': __ResetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__GetDependency__', {
     'value': __GetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__get__', {
     'value': __GetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__RewireAPI__', {
     'value': __RewireAPI__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
 }

--- a/fixtures/transformation/topLevelVar/expected.js
+++ b/fixtures/transformation/topLevelVar/expected.js
@@ -81,26 +81,32 @@ module.exports = out;
 if (typeof module.exports === 'object' || typeof module.exports === 'function') {
   Object.defineProperty(module.exports, '__Rewire__', {
     'value': __Rewire__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__set__', {
     'value': __Rewire__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__ResetDependency__', {
     'value': __ResetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__GetDependency__', {
     'value': __GetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__get__', {
     'value': __GetDependency__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
   Object.defineProperty(module.exports, '__RewireAPI__', {
     'value': __RewireAPI__,
-    'enumberable': false
+    'enumberable': false,
+    'configurable': true
   });
 }

--- a/src/babel-plugin-rewire.js
+++ b/src/babel-plugin-rewire.js
@@ -320,7 +320,8 @@ module.exports = function(pluginArguments) {
 function addNonEnumerableProperty(t, objectIdentifier, propertyName, valueIdentifier) {
 	return t.expressionStatement(t.callExpression(t.memberExpression(t.identifier('Object'), t.identifier('defineProperty')), [ objectIdentifier, t.literal(propertyName),  t.objectExpression([
 		t.property('init', t.literal('value'), valueIdentifier),
-		t.property('init', t.literal('enumberable'), t.literal(false))
+		t.property('init', t.literal('enumberable'), t.literal(false)),
+		t.property('init', t.literal('configurable'), t.literal(true))
 	])]));
 }
 


### PR DESCRIPTION
This corrects my issue and enables this plugin to run under [wallaby.js](http://wallabyjs.com).

Though I did not correct the "enumberable" typo, there will still be a conflict due to the comma, so maybe I should have.

Please don't ask me to write functional tests for this.  :smile: