### PR TITLE
add babel-core as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   }],
   "license": "ISC",
   "devDependencies": {
+    "babel-core": ">=5.7.0",
     "babel-runtime": "^5.8.20",
     "core-js": "^1.0.0",
     "expect.js": "^0.3.1",


### PR DESCRIPTION
This makes it a bit easier to just pick up the package and hack on it; otherwise it's a manual `npm install babel-core`.

I matched the dependency version in `peerDependencies` instead of the latest.