### PR TITLE
Default specifiers to empty array

### DIFF
--- a/fixtures/transformation/wildcardExport/expected.js
+++ b/fixtures/transformation/wildcardExport/expected.js
@@ -1,0 +1,1 @@
+export * from 'path/to/thing';

--- a/fixtures/transformation/wildcardExport/input.js
+++ b/fixtures/transformation/wildcardExport/input.js
@@ -1,0 +1,1 @@
+export * from 'path/to/thing';

--- a/src/babel-plugin-rewire.js
+++ b/src/babel-plugin-rewire.js
@@ -56,7 +56,7 @@ module.exports = function({ types: t }) {
 			}
 		},
 
-		'ExportNamedDeclaration|ExportAllDeclaration': function ({ node: { specifiers } }, rewireInformation) {
+		'ExportNamedDeclaration|ExportAllDeclaration': function ({ node: { specifiers = [] } }, rewireInformation) {
 			let hasDefaultExport = specifiers.some(function(specifier) {
 				return specifier.local.name === 'default';
 			});

--- a/test/BabelRewirePluginTransformTest.js
+++ b/test/BabelRewirePluginTransformTest.js
@@ -84,6 +84,7 @@ describe('BabelRewirePluginTest', function() {
 		'noDefaultExport',
 		'primitiveExportWithNamedFunctionExport',
 		'wildcardImport',
+		'wildcardExport',
 		'recursiveRewireCall',
 		'requireExports',
 		'requireMultiExports',


### PR DESCRIPTION
When using a wildcard export, specifiers becomes undefined. By defaulting to an empty array, we can avoid having to check for it being undefined later.