### PR TITLE
Adding a failing test for pass through modules

### DIFF
--- a/samples/passThrough/sample.js
+++ b/samples/passThrough/sample.js
@@ -1,0 +1,13 @@
+let base = require('./src/base');
+let expect = require('expect.js').expect;
+
+describe('Should enable rewiring a passed through module', function() {
+  it('should not throw', function() {
+    delete require.cache[require.resolve('./src/base')];
+    var passThrough = require('./src/passThrough');
+
+    expect(base.get('foo')).to.be('bar');
+    passThrough.__set__('foo', 'baz');
+    expect(base.get('foo')).to.be('baz');
+  });
+});

--- a/samples/passThrough/src/base.js
+++ b/samples/passThrough/src/base.js
@@ -1,0 +1,7 @@
+var foo = 'bar';
+
+module.exports = {
+  get: function() {
+    return foo;
+  }
+};

--- a/samples/passThrough/src/passThrough.js
+++ b/samples/passThrough/src/passThrough.js
@@ -1,2 +1,1 @@
-var base = require('./base');
-module.exports = base;
+module.exports = require('./base');

--- a/samples/passThrough/src/passThrough.js
+++ b/samples/passThrough/src/passThrough.js
@@ -1,0 +1,2 @@
+var base = require('./base');
+module.exports = base;

--- a/usage-tests/BabelRewirePluginUsageTest.js
+++ b/usage-tests/BabelRewirePluginUsageTest.js
@@ -55,6 +55,7 @@ require('../samples/namedExportRewireSupport/sample.js');
 require('../samples/namedExportsWithNameClash/sample.js');
 require('../samples/nestedScopes/sample.js');
 require('../samples/objectLiteralNameClash/sample.js');
+require('../samples/passThrough/sample.js');
 require('../samples/defaultExportNonExtensible/sample.js');
 require('../samples/typedExport/sample.js');
 require('../samples/nonEnumerableProperties/sample.js');


### PR DESCRIPTION
We sometimes use proxyquire to pass in modules dependencies to other modules. If the module we are passing in was already rewired, then rewire shouldn't attempt to modify it and just let it pass through.

Removing the module from the require cache is effectively what proxyquire is doing.

This error has also manifested itself as:

```
Duplicate declaration "typeOfOriginalExport"
```