### PR TITLE
Add failing test case for compiling switch statements that reference imports

### DIFF
--- a/fixtures/transformation/switch/expected.js
+++ b/fixtures/transformation/switch/expected.js
@@ -1,0 +1,163 @@
+import React from 'react';
+import ComponentA from './ComponentA'
+import ComponentB from './ComponentB'
+import ComponentC from './ComponentC'
+import DefaultComponent from './DefaultComponent'
+
+export default class Foo extends _get__('React').Component {
+	render() {
+		let _ChildComponent_Component = _get__('ChildComponent');
+
+		return <div>
+				{['a', 'b', 'c'].map(this.renderChild)}
+			</div>;
+	}
+
+		renderChild(type) {
+			switch (type) {
+				case 'a':
+					let _ComponentA_Component = _get__('ComponentA');
+					return <_ComponentA_Component />;
+
+				case 'b':
+					let _ComponentB_Component = _get__('ComponentB');
+					return <_ComponentB_Component />;
+
+				case 'c':
+					let _ComponentC_Component = _get__('ComponentC');
+					return <_ComponentC_Component />;
+
+				default:
+					let _DefaultComponent_Component = _get__('DefaultComponent');
+					return <_DefaultComponent_Component />;
+			}
+		}
+}
+let typeOfOriginalExport = typeof Foo;
+
+function addNonEnumerableProperty(name, value) {
+	Object.defineProperty(Foo, name, {
+		value: value,
+		enumerable: false,
+		configurable: true
+	});
+}
+
+if ((typeOfOriginalExport === 'object' || typeOfOriginalExport === 'function') && Object.isExtensible(Foo)) {
+	addNonEnumerableProperty('__get__', _get__);
+	addNonEnumerableProperty('__GetDependency__', _get__);
+	addNonEnumerableProperty('__Rewire__', _set__);
+	addNonEnumerableProperty('__set__', _set__);
+	addNonEnumerableProperty('__reset__', _reset__);
+	addNonEnumerableProperty('__ResetDependency__', _reset__);
+	addNonEnumerableProperty('__with__', _with__);
+	addNonEnumerableProperty('__RewireAPI__', _RewireAPI__);
+}
+
+let _RewiredData__ = {};
+
+function _get__(variableName) {
+	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+}
+
+function _get_original__(variableName) {
+	switch (variableName) {
+		case 'ComponentA':
+			return ComponentA;
+
+		case 'ComponentB':
+			return ComponentB;
+
+		case 'ComponentC':
+			return ComponentC;
+
+		case 'DefaultComponent':
+			return DefaultComponent;
+
+		case 'React':
+			return React;
+	}
+
+	return undefined;
+}
+
+function _assign__(variableName, value) {
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _set_original__(variableName, value);
+	} else {
+		return _RewiredData__[variableName] = value;
+	}
+}
+
+function _set_original__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
+}
+
+function _update_operation__(operation, variableName, prefix) {
+	var oldValue = _get__(variableName);
+
+	var newValue = operation === '++' ? oldValue + 1 : oldValue - 1;
+
+	_assign__(variableName, newValue);
+
+	return prefix ? newValue : oldValue;
+}
+
+function _set__(variableName, value) {
+	return _RewiredData__[variableName] = value;
+}
+
+function _reset__(variableName) {
+	delete _RewiredData__[variableName];
+}
+
+function _with__(object) {
+	var rewiredVariableNames = Object.keys(object);
+	var previousValues = {};
+
+	function reset() {
+		rewiredVariableNames.forEach(function (variableName) {
+			_RewiredData__[variableName] = previousValues[variableName];
+		});
+	}
+
+	return function (callback) {
+		rewiredVariableNames.forEach(function (variableName) {
+			previousValues[variableName] = _RewiredData__[variableName];
+			_RewiredData__[variableName] = object[variableName];
+		});
+		let result = callback();
+
+		if (!!result && typeof result.then == 'function') {
+			result.then(reset).catch(reset);
+		} else {
+			reset();
+		}
+
+		return result;
+	};
+}
+
+let _RewireAPI__ = {};
+
+(function () {
+	function addPropertyToAPIObject(name, value) {
+		Object.defineProperty(_RewireAPI__, name, {
+			value: value,
+			enumerable: false,
+			configurable: true
+		});
+	}
+
+	addPropertyToAPIObject('__get__', _get__);
+	addPropertyToAPIObject('__GetDependency__', _get__);
+	addPropertyToAPIObject('__Rewire__', _set__);
+	addPropertyToAPIObject('__set__', _set__);
+	addPropertyToAPIObject('__reset__', _reset__);
+	addPropertyToAPIObject('__ResetDependency__', _reset__);
+	addPropertyToAPIObject('__with__', _with__);
+})();
+
+export { _get__ as __get__, _get__ as __GetDependency__, _set__ as __Rewire__, _set__ as __set__, _reset__ as __ResetDependency__, _RewireAPI__ as __RewireAPI__ };

--- a/fixtures/transformation/switch/input.js
+++ b/fixtures/transformation/switch/input.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import ComponentA from './ComponentA'
+import ComponentB from './ComponentB'
+import ComponentC from './ComponentC'
+import DefaultComponent from './DefaultComponent'
+
+export default class Foo extends React.Component {
+	render() {
+		return (
+			<div>
+				{['a', 'b', 'c'].map(this.renderChild)}
+			</div>
+		)
+	}
+
+	renderChild(type) {
+		switch (type) {
+			case 'a':
+				return (
+					<ComponentA />
+				)
+			case 'b':
+				return (
+					<ComponentB />
+				)
+			case 'c':
+				return (
+					<ComponentC />
+				)
+			default:
+				return (
+					<DefaultComponent />
+				)
+		}
+	}
+}

--- a/test/BabelRewirePluginTransformTest.js
+++ b/test/BabelRewirePluginTransformTest.js
@@ -90,6 +90,7 @@ describe('BabelRewirePluginTest', function() {
 		'recursiveRewireCall',
 		'requireExports',
 		'requireMultiExports',
+		'switch',
 		'topLevelVar',
 		'functionRewireScope',
 		'issue69',


### PR DESCRIPTION
I ran into an issue where switch statements that reference imports are being transpiled incorrectly, resulting in a syntax error. I have attached a failing test case with what I think the expected output should be.

Example source:
```js
import React from 'react'
import ComponentA from './ComponentA'
import ComponentB from './ComponentB'
import ComponentC from './ComponentC'
import DefaultComponent from './DefaultComponent'

export default class Foo extends React.Component {
	render() {
		return (
			<div>
				{['a', 'b', 'c'].map(this.renderChild)}
			</div>
		)
	}

	renderChild(type) {
		switch (type) {
			case 'a':
				return (
					<ComponentA />
				)
			case 'b':
				return (
					<ComponentB />
				)
			case 'c':
				return (
					<ComponentC />
				)
			default:
				return (
					<DefaultComponent />
				)
		}
	}
}
```

The rewire transform outputs a `renderChild()` that looks like this, with variable declarations outside the case statements:

```js
renderChild(type) {
		switch (type) {
			let _ComponentA_Component = _get__('ComponentA');

			case 'a':
				return <_ComponentA_Component />;

			let _ComponentB_Component = _get__('ComponentB');

			case 'b':
				return <_ComponentB_Component />;

			let _ComponentC_Component = _get__('ComponentC');

			case 'c':
				return <_ComponentC_Component />;

			let _DefaultComponent_Component = _get__('DefaultComponent');

			default:
				return <_DefaultComponent_Component />;
		}
	}
```

I think the expected output should look something like this, with the variable declarations inside the case statements:

```js
		renderChild(type) {
			switch (type) {
				case 'a':
					let _ComponentA_Component = _get__('ComponentA');
					return <_ComponentA_Component />;

				case 'b':
					let _ComponentB_Component = _get__('ComponentB');
					return <_ComponentB_Component />;

				case 'c':
					let _ComponentC_Component = _get__('ComponentC');
					return <_ComponentC_Component />;

				default:
					let _DefaultComponent_Component = _get__('DefaultComponent');
					return <_DefaultComponent_Component />;
			}
		}
```