### PR TITLE
Add an ability to redefine a dependency to undefined

### DIFF
--- a/fixtures/transformation/assignmentOperations/expected.js
+++ b/fixtures/transformation/assignmentOperations/expected.js
@@ -56,6 +56,7 @@ export function bitwiseXorAssignment(operand) {
 	return _assign__('value', _get__('value') ^ operand);
 }
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -77,7 +78,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -122,7 +133,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/babelissue1315/expected.js
+++ b/fixtures/transformation/babelissue1315/expected.js
@@ -43,6 +43,7 @@ else if (_get__('moduleName') === 'outside') {
 
 _get__('$')(() => _get__('ie8Icons').fix());
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -64,7 +65,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -118,7 +129,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/commonJSExportOnly/expected.js
+++ b/fixtures/transformation/commonJSExportOnly/expected.js
@@ -6,6 +6,7 @@ module.exports = {
 	}
 };
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -27,7 +28,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -69,7 +80,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/defaultExportWithObject/expected.js
+++ b/fixtures/transformation/defaultExportWithObject/expected.js
@@ -7,6 +7,7 @@ let _DefaultExportValue = {
 };
 export default _DefaultExportValue;
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -28,7 +29,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -70,7 +81,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/forOf/expected.js
+++ b/fixtures/transformation/forOf/expected.js
@@ -5,6 +5,7 @@ for (let b of a) {
 	_get__('expect')(_get__('ComponentToTest').__Get__('node')).to.be('hey I\'m mock');
 }
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -26,7 +27,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -71,7 +82,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/functionRewireScope/expected.js
+++ b/fixtures/transformation/functionRewireScope/expected.js
@@ -6,6 +6,7 @@ function greet(whoToGreet) {
 	return 'Hello ' + whoToGreet;
 }
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -27,7 +28,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -72,7 +83,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/ignoredIdentifiers/expected.js
+++ b/fixtures/transformation/ignoredIdentifiers/expected.js
@@ -10,6 +10,7 @@ const obj = {
 
 module.exports = _get__('obj');
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -31,7 +32,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-  return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+  if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+    return _get_original__(variableName);
+  } else {
+    var value = _RewiredData__[variableName];
+
+    if (value === INTENTIONAL_UNDEFINED) {
+      return undefined;
+    } else {
+      return value;
+    }
+  }
 }
 
 function _get_original__(variableName) {
@@ -76,7 +87,13 @@ function _set__(variableName, value) {
       _RewiredData__[name] = variableName[name];
     });
   } else {
-    return _RewiredData__[variableName] = value;
+    if (value === undefined) {
+      _RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+    } else {
+      _RewiredData__[variableName] = value;
+    }
+
+    return value;
   }
 }
 

--- a/fixtures/transformation/importWithReactClass/expected.js
+++ b/fixtures/transformation/importWithReactClass/expected.js
@@ -27,6 +27,7 @@ class WelcomePanel extends _get__('Card') {
 let _DefaultExportValue = { WelcomePanel: _get__('WelcomePanel') };
 export default _DefaultExportValue;
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -48,7 +49,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -96,7 +107,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/issue16/expected.js
+++ b/fixtures/transformation/issue16/expected.js
@@ -111,6 +111,7 @@ module.exports = {
   URLInput: _get__('URLInput')
 };
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -132,7 +133,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-  return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+  if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+    return _get_original__(variableName);
+  } else {
+    var value = _RewiredData__[variableName];
+
+    if (value === INTENTIONAL_UNDEFINED) {
+      return undefined;
+    } else {
+      return value;
+    }
+  }
 }
 
 function _get_original__(variableName) {
@@ -225,7 +236,13 @@ function _set__(variableName, value) {
       _RewiredData__[name] = variableName[name];
     });
   } else {
-    return _RewiredData__[variableName] = value;
+    if (value === undefined) {
+      _RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+    } else {
+      _RewiredData__[variableName] = value;
+    }
+
+    return value;
   }
 }
 

--- a/fixtures/transformation/issue69/expected.js
+++ b/fixtures/transformation/issue69/expected.js
@@ -6,6 +6,7 @@ export var Status;
 })(_get__("Status") || _assign__("Status", {}));
 ;
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -27,7 +28,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -72,7 +83,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/issue71-tdz-index/expected.js
+++ b/fixtures/transformation/issue71-tdz-index/expected.js
@@ -8,6 +8,7 @@ export function getLogConstant() {
 let _DefaultExportValue = 'test';
 export default _DefaultExportValue;
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -29,7 +30,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -74,7 +85,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/issue71-tdz/expected.js
+++ b/fixtures/transformation/issue71-tdz/expected.js
@@ -5,6 +5,7 @@ const getLog = function (category) {
 
 export default _get__("getLog");
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -26,7 +27,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -68,7 +79,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/issuePathReplaceWith/expected.js
+++ b/fixtures/transformation/issuePathReplaceWith/expected.js
@@ -8,6 +8,7 @@ let _DefaultExportValue = _get__('createSingleFieldValidatorFactory')(_get__('re
 
 export default _DefaultExportValue;
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -29,7 +30,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -74,7 +85,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/namedFunctionExport/expected.js
+++ b/fixtures/transformation/namedFunctionExport/expected.js
@@ -6,6 +6,7 @@ export default function _DefaultExportValue(val) {
 	return _get__("namedFunction")(val);
 }
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -27,7 +28,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -69,7 +80,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/namedFunctionImport/expected.js
+++ b/fixtures/transformation/namedFunctionImport/expected.js
@@ -9,6 +9,7 @@ export function run() {
 	_get__('foo')('bar');
 }
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -30,7 +31,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -72,7 +83,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/namedVariableExport/expected.js
+++ b/fixtures/transformation/namedVariableExport/expected.js
@@ -9,6 +9,7 @@ export default function _DefaultExportValue(val) {
 	return _get__("namedVariable")(val) + _get__("namedVariable2")(val);
 }
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -30,7 +31,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -75,7 +86,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
+++ b/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
@@ -9,6 +9,7 @@ export function addOne(val) {
 let _DefaultExportValue = 4;
 export default _DefaultExportValue;
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -30,7 +31,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -72,7 +83,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/recursiveRewireCall/expected.js
+++ b/fixtures/transformation/recursiveRewireCall/expected.js
@@ -92,6 +92,7 @@ describe('NamedExportRewireSupportTest', function () {
 	});
 });
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -113,7 +114,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -188,7 +199,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/requireExports/expected.js
+++ b/fixtures/transformation/requireExports/expected.js
@@ -6,6 +6,7 @@ function out(todo) {
 
 module.exports = _get__('out');
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -27,7 +28,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-  return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+  if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+    return _get_original__(variableName);
+  } else {
+    var value = _RewiredData__[variableName];
+
+    if (value === INTENTIONAL_UNDEFINED) {
+      return undefined;
+    } else {
+      return value;
+    }
+  }
 }
 
 function _get_original__(variableName) {
@@ -72,7 +83,13 @@ function _set__(variableName, value) {
       _RewiredData__[name] = variableName[name];
     });
   } else {
-    return _RewiredData__[variableName] = value;
+    if (value === undefined) {
+      _RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+    } else {
+      _RewiredData__[variableName] = value;
+    }
+
+    return value;
   }
 }
 

--- a/fixtures/transformation/requireMultiExports/expected.js
+++ b/fixtures/transformation/requireMultiExports/expected.js
@@ -7,6 +7,7 @@ function out(todo) {
 module.exports.out = _get__('out');
 module.exports.other = 'Foo';
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -28,7 +29,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-  return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+  if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+    return _get_original__(variableName);
+  } else {
+    var value = _RewiredData__[variableName];
+
+    if (value === INTENTIONAL_UNDEFINED) {
+      return undefined;
+    } else {
+      return value;
+    }
+  }
 }
 
 function _get_original__(variableName) {
@@ -73,7 +84,13 @@ function _set__(variableName, value) {
       _RewiredData__[name] = variableName[name];
     });
   } else {
-    return _RewiredData__[variableName] = value;
+    if (value === undefined) {
+      _RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+    } else {
+      _RewiredData__[variableName] = value;
+    }
+
+    return value;
   }
 }
 

--- a/fixtures/transformation/rewiringOfReactComponents/expected.js
+++ b/fixtures/transformation/rewiringOfReactComponents/expected.js
@@ -11,6 +11,7 @@ export default class Foo extends _get__('React').Component {
 	}
 }
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -32,7 +33,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -77,7 +88,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/rewiringOfSimpleFunctionalComponents/expected.js
+++ b/fixtures/transformation/rewiringOfSimpleFunctionalComponents/expected.js
@@ -47,6 +47,7 @@ let _DefaultExportValue = () => {
 
 export default _DefaultExportValue;
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -68,7 +69,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -116,7 +127,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/switch/expected.js
+++ b/fixtures/transformation/switch/expected.js
@@ -33,6 +33,7 @@ export default class Foo extends _get__('React').Component {
 	}
 }
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -54,7 +55,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -108,7 +119,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/topLevelVar/expected.js
+++ b/fixtures/transformation/topLevelVar/expected.js
@@ -10,6 +10,7 @@ function out(todo) {
 
 module.exports = _get__('out');
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -31,7 +32,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-  return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+  if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+    return _get_original__(variableName);
+  } else {
+    var value = _RewiredData__[variableName];
+
+    if (value === INTENTIONAL_UNDEFINED) {
+      return undefined;
+    } else {
+      return value;
+    }
+  }
 }
 
 function _get_original__(variableName) {
@@ -79,7 +90,13 @@ function _set__(variableName, value) {
       _RewiredData__[name] = variableName[name];
     });
   } else {
-    return _RewiredData__[variableName] = value;
+    if (value === undefined) {
+      _RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+    } else {
+      _RewiredData__[variableName] = value;
+    }
+
+    return value;
   }
 }
 

--- a/fixtures/transformation/updateOperations/expected.js
+++ b/fixtures/transformation/updateOperations/expected.js
@@ -19,6 +19,7 @@ export function postDecrement() {
 	return _update_operation__("--", "postDecrementValue", false);
 }
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -40,7 +41,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-	return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+	if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+		return _get_original__(variableName);
+	} else {
+		var value = _RewiredData__[variableName];
+
+		if (value === INTENTIONAL_UNDEFINED) {
+			return undefined;
+		} else {
+			return value;
+		}
+	}
 }
 
 function _get_original__(variableName) {
@@ -103,7 +114,13 @@ function _set__(variableName, value) {
 			_RewiredData__[name] = variableName[name];
 		});
 	} else {
-		return _RewiredData__[variableName] = value;
+		if (value === undefined) {
+			_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+		} else {
+			_RewiredData__[variableName] = value;
+		}
+
+		return value;
 	}
 }
 

--- a/fixtures/transformation/wildcardImport/expected.js
+++ b/fixtures/transformation/wildcardImport/expected.js
@@ -10,6 +10,7 @@ describe('wildcard export of imported object', () => {
 		});
 });
 var _RewiredData__ = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 let _RewireAPI__ = {};
 
 (function () {
@@ -31,7 +32,17 @@ let _RewireAPI__ = {};
 })();
 
 function _get__(variableName) {
-		return _RewiredData__ === undefined || _RewiredData__[variableName] === undefined ? _get_original__(variableName) : _RewiredData__[variableName];
+		if (_RewiredData__ === undefined || _RewiredData__[variableName] === undefined) {
+				return _get_original__(variableName);
+		} else {
+				var value = _RewiredData__[variableName];
+
+				if (value === INTENTIONAL_UNDEFINED) {
+						return undefined;
+				} else {
+						return value;
+				}
+		}
 }
 
 function _get_original__(variableName) {
@@ -82,7 +93,13 @@ function _set__(variableName, value) {
 						_RewiredData__[name] = variableName[name];
 				});
 		} else {
-				return _RewiredData__[variableName] = value;
+				if (value === undefined) {
+						_RewiredData__[variableName] = INTENTIONAL_UNDEFINED;
+				} else {
+						_RewiredData__[variableName] = value;
+				}
+
+				return value;
 		}
 }
 

--- a/samples/rewireToUndefined/sample.js
+++ b/samples/rewireToUndefined/sample.js
@@ -1,0 +1,18 @@
+import {test, __Rewire__, __ResetDependency__} from './src/ModuleToTest';
+import expect from 'expect.js';
+
+describe('an ability to override a dependency to undefined', () => {
+  afterEach(() => {
+    __ResetDependency__('shouldNotFail')
+  })
+
+  it('allows to override a dependency to a number', () =>{
+    __Rewire__('shouldNotFail', 123)
+    expect(test).to.throwException(TypeError)
+  });
+
+  it('allows to override a dependency to undefined', () =>{
+    __Rewire__('shouldNotFail', undefined)
+    expect(test).to.throwException(TypeError)
+  });
+});

--- a/samples/rewireToUndefined/src/ModuleToTest.js
+++ b/samples/rewireToUndefined/src/ModuleToTest.js
@@ -1,0 +1,5 @@
+const shouldNotFail = () => {}
+
+export function test () {
+  shouldNotFail()
+}

--- a/src/Templates.js
+++ b/src/Templates.js
@@ -16,6 +16,7 @@ import template from 'babel-template';
 
 export const universalAccesorsTemplate = template(`
 var REWIRED_DATA_IDENTIFIER = {};
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
 
 let API_OBJECT_ID = {};
 
@@ -34,7 +35,16 @@ let API_OBJECT_ID = {};
 })();
 
 function UNIVERSAL_GETTER_ID(variableName) {
-	return (REWIRED_DATA_IDENTIFIER === undefined || REWIRED_DATA_IDENTIFIER[variableName] === undefined) ? ORIGINAL_VARIABLE_ACCESSOR_IDENTIFIER(variableName) : REWIRED_DATA_IDENTIFIER[variableName];
+  if (REWIRED_DATA_IDENTIFIER === undefined || REWIRED_DATA_IDENTIFIER[variableName] === undefined) {
+    return ORIGINAL_VARIABLE_ACCESSOR_IDENTIFIER(variableName);
+  } else {
+    var value = REWIRED_DATA_IDENTIFIER[variableName];
+    if (value === INTENTIONAL_UNDEFINED) {
+      return undefined;
+    } else {
+      return value;
+    }
+  }
 }
 
 ORIGINAL_ACCESSOR
@@ -62,7 +72,13 @@ function UNIVERSAL_SETTER_ID(variableName, value) {
 			REWIRED_DATA_IDENTIFIER[name] = variableName[name];
 		});
 	} else {
-		return REWIRED_DATA_IDENTIFIER[variableName] = value;
+    if (value === undefined) {
+      REWIRED_DATA_IDENTIFIER[variableName] = INTENTIONAL_UNDEFINED
+    } else {
+      REWIRED_DATA_IDENTIFIER[variableName] = value
+    }
+
+    return value
 	}
 }
 

--- a/usage-tests/BabelRewirePluginUsageTest.js
+++ b/usage-tests/BabelRewirePluginUsageTest.js
@@ -74,4 +74,5 @@ require('../samples/namedWildcardExport/sample.js');
 require('../samples/assignmentOperations/sample.js');
 require('../samples/jsx-switch/sample.js');
 require('../samples/jsx-stateless-multilevel/sample.js');
+require('../samples/rewireToUndefined/sample.js');
 hook.unhook('.js'); // removes your own transform


### PR DESCRIPTION
Right now the plugin doesn't allow to set undefined as the value in the getter.

It's useful when you need to emulate a missing features, e.g:

```js
const localStorage = window.localStorage
// In a test:
__Rewire__('localStorage', undefined)
```