### PR TITLE
Add test cases for missing JSX support (or an intentional limitation ¯\_(ツ)_/¯)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "node-hook": "^0.1.0",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
-    "should": "^9.0.2"
+    "should": "^9.0.2",
+    "sinon": "^1.17.4"
   },
   "peerDependencies": {
     "babel-core": "^6.0.0",

--- a/samples/jsxSupport/sample.js
+++ b/samples/jsxSupport/sample.js
@@ -1,0 +1,21 @@
+import test from './src/ModuleToTest';
+import expect from 'expect.js';
+import sinon from 'sinon'
+
+describe('JSX support', () => {
+  afterEach(() => {
+    test.__ResetDependency__('shouldFail')
+  })
+
+  it('allows to override React', () =>{
+    test.__Rewire__('React', {createElement: () => {}});
+    expect(test).to.not.throwException(ReferenceError);
+  });
+
+  it('allows to override a component', () =>{
+    const createElement = sinon.spy();
+    test.__Rewire__('React', {createElement});
+    test.__Rewire__('Component', 'component class');
+    expect(createElement.calledWith('component class')).to.be(true);
+  });
+});

--- a/samples/jsxSupport/src/ModuleToTest.js
+++ b/samples/jsxSupport/src/ModuleToTest.js
@@ -1,0 +1,6 @@
+const React = {createElement: () => { fail() }}
+const Component = () => {}
+
+export default function test () {
+  <Component />
+}

--- a/usage-tests/BabelRewirePluginUsageTest.js
+++ b/usage-tests/BabelRewirePluginUsageTest.js
@@ -78,4 +78,5 @@ require('../samples/rewireToUndefined/sample.js');
 require('../samples/issue115-should-js/sample.js');
 require('../samples/issue140-chai-should/sample.js');
 require('../samples/issue130-jsx-es6-type-imports/sample.js');
+require('../samples/jsxSupport/sample.js');
 hook.unhook('.js'); // removes your own transform


### PR DESCRIPTION
It turned out that babel-plugin-rewire doesn’t allow to override both `React` and `Component` in `React.createClass(Component)` generated from JSX code `<Component />`.

After debugging I realized that `React` and `Component` aren’t wrapped into `__get__` calls.

The PR adds test cases for the described problem.

When I've tried to write a fix it turned out the plugin relies on visiting `JSXElement`, but not resulting code. This approach works well with stuff like `enzyme`, but doesn't allow to test root entry of the application.

Not sure what to do here. @speedskater WDYT?