### PR TITLE
Add test case for a bug caused by nested functions

### DIFF
--- a/samples/nestedFunctionsBug/sample.js
+++ b/samples/nestedFunctionsBug/sample.js
@@ -1,0 +1,8 @@
+import test from './src/ModuleToTest';
+import expect from 'expect.js';
+
+describe('nested functions bug', () => {
+  it('has rewire API', () =>{
+    expect(typeof test.__Rewire__).to.be('function');
+  });
+});

--- a/samples/nestedFunctionsBug/src/ModuleToTest.js
+++ b/samples/nestedFunctionsBug/src/ModuleToTest.js
@@ -1,0 +1,3 @@
+export default function test () {
+  function nestedFuntion () {}
+}

--- a/usage-tests/BabelRewirePluginUsageTest.js
+++ b/usage-tests/BabelRewirePluginUsageTest.js
@@ -78,4 +78,5 @@ require('../samples/rewireToUndefined/sample.js');
 require('../samples/issue115-should-js/sample.js');
 require('../samples/issue140-chai-should/sample.js');
 require('../samples/issue130-jsx-es6-type-imports/sample.js');
+require('../samples/nestedFunctionsBug/sample.js');
 hook.unhook('.js'); // removes your own transform


### PR DESCRIPTION
For some reason rewire API doesn't available in a function which has a nested function.

I'll try to fix this as soon as I'll have some time.