### PR TITLE
Test that shows Sinon incompatibility

### DIFF
--- a/samples/issue174/sample.js
+++ b/samples/issue174/sample.js
@@ -1,0 +1,15 @@
+import * as test from './src/ModuleToTest';
+import expect from 'expect.js';
+import sinon from 'sinon'
+
+describe('Sinon stub support', () => {
+  it('doesnt break sinon stubs', () => {
+    expect('Hello').to.equal(test.sayHello());
+
+    let stub = sinon.stub(test, 'sayHello', () => { return "Goodbye" });
+    expect('Goodbye').to.equal(test.sayHello());
+
+    stub.restore();
+    expect('Hello').to.equal(test.sayHello());
+  });
+});

--- a/samples/issue174/src/ModuleToTest.js
+++ b/samples/issue174/src/ModuleToTest.js
@@ -1,0 +1,3 @@
+export function sayHello() {
+  return 'Hello';
+}

--- a/usage-tests/BabelRewirePluginUsageTest.js
+++ b/usage-tests/BabelRewirePluginUsageTest.js
@@ -78,7 +78,7 @@ var configurations = {
 			'issue163',
 			'issue165',
 			'issue109',
-      'issue174'
+			'issue174'
 		]
 	},
 	transformSampleCodeToTestWithBabelPluginRewireAndTransformAsyncToGenerator: {

--- a/usage-tests/BabelRewirePluginUsageTest.js
+++ b/usage-tests/BabelRewirePluginUsageTest.js
@@ -77,7 +77,8 @@ var configurations = {
 			'issue146-revert-function-for-set',
 			'issue163',
 			'issue165',
-			'issue109'
+			'issue109',
+      'issue174'
 		]
 	},
 	transformSampleCodeToTestWithBabelPluginRewireAndTransformAsyncToGenerator: {


### PR DESCRIPTION
This test shows that Sinon stubbing is broken by babel-plugin-rewire