### PR TITLE
Fixes undefined __$$GLOBAL_REWIRE_REGISTRY__ error.

### DIFF
--- a/src/Templates.js
+++ b/src/Templates.js
@@ -48,7 +48,7 @@ function GET_REWIRE_REGISTRY_IDENTIFIER() {
 	if(!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
 	}
-	return __$$GLOBAL_REWIRE_REGISTRY__; 
+	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__; 
 }
 
 function GET_REWIRE_DATA_IDENTIFIER() {


### PR DESCRIPTION
Fixes undefined variable probably due to copy/paste oversight that causes problems downstream with redbox-react.

This fix should also go into the 2.x branch.

See https://github.com/naviapps/nw-react-boilerplate/issues/4 for the bug that this fixes.