### PR TITLE
Add support for object spread

### DIFF
--- a/samples/objectRestProperty/sample.js
+++ b/samples/objectRestProperty/sample.js
@@ -1,0 +1,11 @@
+import expect from 'expect.js';
+
+import { userCreatedAt, __RewireAPI__ } from './src/objectRestPropertyModule';
+
+describe('TestModuleWithComplexObjectSpreads', () => {
+	it('should work', () => {
+		expect(userCreatedAt()).to.eql(10000229393)
+		__RewireAPI__.__Rewire__('metadata', { createdAt: 987654321 })
+		expect(userCreatedAt()).to.eql(987654321)
+	});
+});

--- a/samples/objectRestProperty/src/objectRestPropertyModule.js
+++ b/samples/objectRestProperty/src/objectRestPropertyModule.js
@@ -1,0 +1,6 @@
+const newUser = { id: 123, name: 'John', createdAt: 10000229393, updatedAt: 10000782231 }
+export const { id, name, ...metadata } = newUser
+
+export const userCreatedAt = () => {
+	return metadata.createdAt;
+}

--- a/src/babel-plugin-rewire.js
+++ b/src/babel-plugin-rewire.js
@@ -24,6 +24,7 @@ module.exports = function({ types: t }) {
 		!(parent.type === 'FunctionExpression' && parent.id === node) &&
 		!(parent.type === 'MemberExpression' && parent.property === node) &&
 		!(parent.type === 'ObjectProperty' && parent.key === node) &&
+		!(parent.type === 'RestProperty') &&
 		!(parent.type === 'ObjectMethod' && parent.key === node) &&
 		!(parent.type === 'ObjectProperty' && path.parentPath && path.parentPath.parent && path.parentPath.parent.type === 'ObjectPattern') &&
 		!(parent.type === 'ExportSpecifier') &&

--- a/usage-tests/BabelRewirePluginUsageTest.js
+++ b/usage-tests/BabelRewirePluginUsageTest.js
@@ -115,6 +115,18 @@ var configurations = {
 		samples: [
 			'issue151-flow'
 		]
+	},
+	transformSampleCodeToTestWithBabelPluginRewireAndObjectRestProperty: {
+		transformOptions: {
+			"presets": ["es2015"],
+			"plugins": [
+				babelPluginRewire,
+				"transform-object-rest-spread"
+			]
+		},
+		samples: [
+			"objectRestProperty"
+		]
 	}
 };
 


### PR DESCRIPTION
Currently invalid syntax is output when transforming object rest properties ([TC39 proposal]). The rewiring seems to work as expected if we simply skip rewiring rest properties.

[TC39 proposal]: https://github.com/tc39/proposal-object-rest-spread

A small example triggering the error would be a module like this:

```js
const newUser = { id: 123, name: 'John', createdAt: 10000229393, updatedAt: 10000782231 }
export const { id, name, ...metadata } = newUser // <- This line makes babel not transform/compile

export const userCreatedAt = () => {
  return metadata.createdAt;
}
```

The code above is also provided in a test in the first of the two commits.