### PR TITLE
Don't rewire TSTypeReference

### DIFF
--- a/src/babel-plugin-rewire.js
+++ b/src/babel-plugin-rewire.js
@@ -31,7 +31,12 @@ module.exports = function({ types: t, template }) {
 		!(parent.type === 'ExportSpecifier') &&
 		!(parent.type === 'ImportSpecifier') &&
 		!(parent.type === 'ObjectTypeProperty') &&
-		!(parent.type === 'ClassMethod')
+		!(parent.type === 'ClassMethod') &&
+		!(parent.type === 'TSDeclareFunction') &&
+		!(parent.type === 'TSExpressionWithTypeArguments') &&
+		!(parent.type === 'TSQualifiedName') &&
+		!(parent.type === 'TSTypeQuery') &&
+		!(parent.type === 'TSTypeReference')
 	}
 
 	function doesIdentifierRepresentAValidReference(path, variableBinding, rewireInformation) {


### PR DESCRIPTION
Fixes: https://github.com/speedskater/babel-plugin-rewire/issues/218

Update: due to this not being merged for a long time I have published a fork as babel-plugin-rewire-ts to unblock myself. You are welcome to use it too. You can contribute any further fixes here https://github.com/rosswarren/babel-plugin-rewire-ts. https://www.npmjs.com/package/babel-plugin-rewire-ts.

I understand you probably want tests for this change, but I have no idea how we can actually do that because the rest of the tests haven't been updated for babel 7 and I can't run `@babel/preset-typescript` against babel 6.