### PR TITLE
Support all variable names

### DIFF
--- a/src/RewireState.js
+++ b/src/RewireState.js
@@ -73,7 +73,7 @@ export default class RewireState {
 	}
 
 	ensureAccessor(variableName, isWildcardImport = false) {
-		if(!this.accessors[variableName]) {
+		if(!this.accessors.hasOwnProperty(variableName)) {
 			this.accessors[variableName] = true;
 			this.addTrackedIdentifier(variableName, isWildcardImport);
 		}


### PR DESCRIPTION
 fix the bug that variables with name in Object.prototype chain such as 'toString', 'valueOf' fail to be added into this.accessors