### PR TITLE
Add support of optional chaining

### DIFF
--- a/src/babel-plugin-rewire.js
+++ b/src/babel-plugin-rewire.js
@@ -31,7 +31,9 @@ module.exports = function({ types: t, template }) {
 		!(parent.type === 'ExportSpecifier') &&
 		!(parent.type === 'ImportSpecifier') &&
 		!(parent.type === 'ObjectTypeProperty') &&
-		!(parent.type === 'ClassMethod')
+		!(parent.type === 'ClassMethod') &&
+		!(parent.type === 'OptionalMemberExpression') &&
+    !(parent.type === 'FunctionDeclaration');
 	}
 
 	function doesIdentifierRepresentAValidReference(path, variableBinding, rewireInformation) {


### PR DESCRIPTION
when starting citimaBackend with the plugin enabled:
```
=> Errors prevented startup:                  
   
   While building for web.browser:
   imports/api/external/zendesk/methods.admin.js: /home/artem-bubnov/work/citima/citimaBackend/imports/api/external/zendesk/methods.admin.js: Property property of OptionalMemberExpression expected node to be of
   a type ["Identifier"] but instead got "CallExpression"
   imports/ui/pages/Admin/Database/Modals/Utils.js: /home/artem-bubnov/work/citima/citimaBackend/imports/ui/pages/Admin/Database/Modals/Utils.js: Property id of FunctionDeclaration expected node to be of a type
   ["Identifier"] but instead got "CallExpression"
   
   While building for web.browser.legacy:
   imports/api/external/zendesk/methods.admin.js: /home/artem-bubnov/work/citima/citimaBackend/imports/api/external/zendesk/methods.admin.js: Property property of OptionalMemberExpression expected node to be of
   a type ["Identifier"] but instead got "CallExpression"
   imports/ui/pages/Admin/Database/Modals/Utils.js: /home/artem-bubnov/work/citima/citimaBackend/imports/ui/pages/Admin/Database/Modals/Utils.js: Property id of FunctionDeclaration expected node to be of a type
   ["Identifier"] but instead got "CallExpression"
   
   While building for os.linux.x86_64:
   imports/api/external/zendesk/methods.admin.js: /home/artem-bubnov/work/citima/citimaBackend/imports/api/external/zendesk/methods.admin.js: Property property of OptionalMemberExpression expected node to be of
   a type ["Identifier"] but instead got "CallExpression"
```

see also https://github.com/speedskater/babel-plugin-rewire/compare/master...guilhermehto:babel-plugin-rewire:master